### PR TITLE
Feature/ticket 학습 티켓 목록 조회 로직 수정

### DIFF
--- a/src/main/java/seong/onlinestudy/controller/TicketController.java
+++ b/src/main/java/seong/onlinestudy/controller/TicketController.java
@@ -47,13 +47,12 @@ public class TicketController {
 
     @PostMapping("/ticket/{id}")
     public Result<Long> expiredTicket(@PathVariable("id") Long ticketId,
-                                      @RequestBody @Valid TicketUpdateRequest ticketUpdateRequest,
                                       @SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember) {
         if(loginMember == null) {
             throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");
         }
 
-        Long updateTicketId = ticketService.expireTicket(ticketId, ticketUpdateRequest, loginMember);
+        Long updateTicketId = ticketService.expireTicket(ticketId, loginMember);
 
         return new Result<>("201", updateTicketId);
     }

--- a/src/main/java/seong/onlinestudy/controller/TicketController.java
+++ b/src/main/java/seong/onlinestudy/controller/TicketController.java
@@ -24,10 +24,9 @@ public class TicketController {
     private final TicketService ticketService;
 
     @GetMapping("/tickets")
-    public Result<List<MemberTicketDto>> getTickets(@Valid TicketGetRequest ticketGetRequest,
-                                                    @SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember) {
+    public Result<List<MemberTicketDto>> getTickets(@Valid TicketGetRequest ticketGetRequest) {
 
-        List<MemberTicketDto> memberTickets = ticketService.getTickets(ticketGetRequest, loginMember);
+        List<MemberTicketDto> memberTickets = ticketService.getTickets(ticketGetRequest);
 
         return new Result<>("200", memberTickets);
     }

--- a/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
@@ -42,9 +42,11 @@ public class StudyRecordDto {
 
     public static StudyRecordDto from(Study study) {
         StudyRecordDto studyRecordDto = new StudyRecordDto();
-        studyRecordDto.studyId = study.getId();
-        studyRecordDto.studyName = study.getName();
-        studyRecordDto.memberCount = 0;
+        if(study != null) {
+            studyRecordDto.studyId = study.getId();
+            studyRecordDto.studyName = study.getName();
+            studyRecordDto.memberCount = 0;
+        }
 
         return studyRecordDto;
     }

--- a/src/main/java/seong/onlinestudy/repository/MemberRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package seong.onlinestudy.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,6 +9,7 @@ import seong.onlinestudy.domain.Group;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.dto.GroupMemberDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,8 +25,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             " join m.groupMembers gm on gm.group.id = :groupId")
     List<Member> findMembersInGroup(@Param("groupId") Long groupId);
 
-//    @Query("select" +
-//            " new seong.onlinestudy.dto.GroupMemberDto(gm.id, g.id, m.id, m.username, m.nickname, gm.joinedAt, gm.role)" +
-//            " from Member m join m.groupMembers gm join gm.group g where g in :content and gm.role='MASTER'")
-//    List<GroupMemberDto> findGroupMasters(@Param("content") List<Group> content);
+    @Query("select m from Member m" +
+            " join m.tickets t" +
+            " join t.record r" +
+            " where t.startTime >= :startTime and t.startTime < :endTime" +
+            " group by m.id" +
+            " order by sum(r.activeTime) desc ")
+    Page<Member> findMembersOrderByStudyTime(@Param("startTime") LocalDateTime startTime,
+                                             @Param("endTime") LocalDateTime endTime,
+                                             Pageable pageable);
 }

--- a/src/main/java/seong/onlinestudy/repository/TicketRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepository.java
@@ -24,7 +24,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRep
      */
     @Query("select t from Ticket t" +
             " join t.member m on m = :member" +
-            " join fetch t.study s" +
+            " left join fetch t.study s" +
             " join fetch t.record r" +
             " where t.startTime >= :startTime and t.startTime < :endTime")
     List<Ticket> findTickets(@Param("member") Member member,

--- a/src/main/java/seong/onlinestudy/repository/TicketRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepositoryCustom.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface TicketRepositoryCustom {
 
+    List<Ticket> findTickets(Long studyId, Long groupId, List<Long> memberIds, LocalDateTime startTime, LocalDateTime endTime);
     List<Ticket> findTickets(Long studyId, Long groupId, Long memberId, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/seong/onlinestudy/repository/TicketRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepositoryImpl.java
@@ -2,7 +2,6 @@ package seong.onlinestudy.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import seong.onlinestudy.domain.QRecord;
 import seong.onlinestudy.domain.Ticket;
 
 import javax.persistence.EntityManager;
@@ -24,6 +23,22 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom{
     }
 
     @Override
+    public List<Ticket> findTickets(Long studyId, Long groupId, List<Long> memberIds, LocalDateTime startTime, LocalDateTime endTime) {
+        List<Ticket> findTickets = query
+                .selectFrom(ticket)
+                .join(ticket.group, group)
+                .leftJoin(ticket.study, study).fetchJoin()
+                .join(ticket.member, member).fetchJoin()
+                .join(ticket.record, record).fetchJoin()
+                .where(studyIdEq(studyId), groupIdEq(groupId), memberIdsIn(memberIds),
+                        ticket.startTime.goe(startTime), ticket.startTime.lt(endTime))
+                .orderBy(study.id.asc(), ticket.startTime.asc())
+                .fetch();
+
+        return findTickets;
+    }
+
+    @Override
     public List<Ticket> findTickets(Long studyId, Long groupId, Long memberId, LocalDateTime startTime, LocalDateTime endTime) {
         List<Ticket> findTickets = query
                 .selectFrom(ticket)
@@ -37,6 +52,10 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom{
                 .fetch();
 
         return findTickets;
+    }
+
+    private BooleanExpression memberIdsIn(List<Long> memberIds) {
+        return memberIds != null && memberIds.size() > 0 ? member.id.in(memberIds) : null;
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/seong/onlinestudy/request/TicketGetRequest.java
+++ b/src/main/java/seong/onlinestudy/request/TicketGetRequest.java
@@ -15,12 +15,14 @@ public class TicketGetRequest {
     LocalDate date;
     int days;
 
+    int page;
+    int size;
+
     public TicketGetRequest() {
         date = LocalDate.now();
         days = 1;
-    }
 
-    public boolean isAnySearchCondition() {
-        return groupId != null || studyId != null;
+        page = 0;
+        size = 30;
     }
 }

--- a/src/main/java/seong/onlinestudy/request/TicketGetRequest.java
+++ b/src/main/java/seong/onlinestudy/request/TicketGetRequest.java
@@ -10,6 +10,7 @@ public class TicketGetRequest {
 
     Long groupId;
     Long studyId;
+    Long memberId;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     LocalDate date;
     int days;

--- a/src/main/java/seong/onlinestudy/service/TicketService.java
+++ b/src/main/java/seong/onlinestudy/service/TicketService.java
@@ -62,7 +62,7 @@ public class TicketService {
     }
 
     @Transactional
-    public Long expireTicket(Long ticketId, TicketUpdateRequest updateTicketRequest, Member loginMember) {
+    public Long expireTicket(Long ticketId, Member loginMember) {
         Ticket findTicket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 티켓입니다."));
 

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -219,6 +219,17 @@ public class MyUtils {
         return tickets;
     }
 
+    public static List<Ticket> createTickets(TicketStatus status, List<Member> members, List<Group> groups,
+                                             List<Study> studies, boolean setId) {
+        List<Ticket> tickets = new ArrayList<>();
+        for(int i=0; i<members.size(); i++) {
+            Ticket ticket = createTicket(status, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
+            tickets.add(ticket);
+            setField(ticket, "id", (long)i);
+        }
+        return tickets;
+    }
+
     public static List<Ticket> createEndTickets(List<Member> members, List<Group> groups, List<Study> studies, long studyTime) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
@@ -232,6 +243,7 @@ public class MyUtils {
         }
         return tickets;
     }
+
 
     public static void expireTickets(List<Ticket> tickets) {
         for (Ticket ticket : tickets) {

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -210,10 +210,10 @@ public class MyUtils {
         }
     }
 
-    public static List<Ticket> createTickets(List<Member> members, List<Group> groups, List<Study> studies) {
+    public static List<Ticket> createTickets(TicketStatus status, List<Member> members, List<Group> groups, List<Study> studies) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createTicket(STUDY, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
+            Ticket ticket = createTicket(status, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
             tickets.add(ticket);
         }
         return tickets;
@@ -231,5 +231,17 @@ public class MyUtils {
             setField(ticket.getRecord(), "activeTime", studyTime);
         }
         return tickets;
+    }
+
+    public static void expireTickets(List<Ticket> tickets) {
+        for (Ticket ticket : tickets) {
+            ticket.expiredAndUpdateRecord();
+        }
+    }
+
+    public static void expireTicket(Ticket ticket, int studyTime) {
+        ticket.expiredAndUpdateRecord();
+        setField(ticket.getRecord(), "activeTime", studyTime);
+        setField(ticket.getRecord(), "expiredTime", ticket.getStartTime().plusSeconds(studyTime));
     }
 }

--- a/src/test/java/seong/onlinestudy/api/TicketApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/TicketApiTest.java
@@ -1,0 +1,84 @@
+package seong.onlinestudy.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import seong.onlinestudy.MyUtils;
+import seong.onlinestudy.domain.*;
+import seong.onlinestudy.repository.GroupRepository;
+import seong.onlinestudy.repository.MemberRepository;
+import seong.onlinestudy.repository.StudyRepository;
+import seong.onlinestudy.repository.TicketRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static seong.onlinestudy.MyUtils.*;
+import static seong.onlinestudy.MyUtils.createTicket;
+import static seong.onlinestudy.domain.TicketStatus.REST;
+import static seong.onlinestudy.domain.TicketStatus.STUDY;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class TicketApiTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    GroupRepository groupRepository;
+    @Autowired
+    StudyRepository studyRepository;
+    @Autowired
+    TicketRepository ticketRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        List<Member> members = createMembers(10);
+        List<Group> groups = createGroups(members, 2);
+        for(int i=2; i<10; i++) {
+            Group group = groups.get(i % 2);
+            group.addGroupMember(GroupMember.createGroupMember(members.get(i), GroupRole.USER));
+        }
+
+        List<Study> studies = createStudies(2);
+        List<Ticket> studyTicketsToExpire = createTickets(STUDY, members, groups, studies);
+        List<Ticket> restTicketsToExpire = createTickets(REST, members, groups, studies);
+        List<Ticket> studyTickets = createTickets(STUDY, members, groups, studies);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        studyRepository.saveAll(studies);
+        ticketRepository.saveAll(studyTicketsToExpire);
+        ticketRepository.saveAll(restTicketsToExpire);
+        ticketRepository.saveAll(studyTickets);
+
+        MyUtils.expireTickets(studyTicketsToExpire);
+        MyUtils.expireTickets(restTicketsToExpire);
+    }
+
+    @Test
+    void getTickets_withoutCondition() throws Exception {
+        //given
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/v1/tickets"));
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
@@ -46,7 +46,7 @@ class TicketControllerTest {
         Ticket ticket = createTicket(TicketStatus.STUDY, member, study, group);
 
         session.setAttribute(SessionConst.LOGIN_MEMBER, member);
-        given(ticketService.expireTicket(any(), any(), any())).willReturn(1L);
+        given(ticketService.expireTicket(any(), any())).willReturn(1L);
 
         //when
         TicketUpdateRequest request = new TicketUpdateRequest();

--- a/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
@@ -117,7 +117,7 @@ public class StudyRepositoryCustomTest {
         MyUtils.joinMembersToGroups(members, groups);
 
         List<Study> studies = createStudies(2);
-        List<Ticket> tickets = createTickets(members, groups, studies);
+        List<Ticket> tickets = createTickets(TicketStatus.STUDY, members, groups, studies);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);

--- a/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
@@ -115,13 +115,6 @@ public class TicketRepositoryCustomTest {
         Long memberId = null;
 
         //when
-/*        List<Ticket> findTickets = query
-                .selectFrom(ticket)
-                .join(ticket.group, group)
-                .join(ticket.study, study).fetchJoin()
-                .join(ticket.member, member).fetchJoin()
-                .where(studyIdEq(studyId), groupIdEq(groupId))
-                .fetch();*/
         List<Ticket> findTickets
                 = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
 
@@ -141,13 +134,6 @@ public class TicketRepositoryCustomTest {
         Long memberId = null;
 
         //when
-/*        List<Ticket> findTickets = query
-                .selectFrom(ticket)
-                .join(ticket.group, group)
-                .join(ticket.study, study).fetchJoin()
-                .join(ticket.member, member).fetchJoin()
-                .where(studyIdEq(studyId), groupIdEq(groupId))
-                .fetch();*/
         List<Ticket> findTickets
                 = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
 
@@ -167,14 +153,6 @@ public class TicketRepositoryCustomTest {
         Long memberId = members.get(0).getId();
 
         //when
-/*        List<Ticket> findTickets = query
-                .selectFrom(ticket)
-                .join(ticket.group, group)
-                .join(ticket.study, study).fetchJoin()
-                .join(ticket.member, member).fetchJoin()
-                .where(studyIdEq(studyId), groupIdEq(groupId), memberIdEq(memberId))
-                .orderBy(study.id.asc())
-                .fetch();*/
         List<Ticket> findTickets
                 = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
 
@@ -186,37 +164,5 @@ public class TicketRepositoryCustomTest {
 
         Set<Member> findMembersRemoveDuplicate = new HashSet<>(findMembers);
         assertThat(findMembersRemoveDuplicate.size()).isEqualTo(1);
-    }
-
-    private BooleanExpression memberIdEq(Long memberId) {
-        return memberId != null ? member.id.eq(memberId) : null;
-    }
-
-    private BooleanExpression groupIdEq(Long groupId) {
-        return groupId != null ? group.id.eq(groupId) : null;
-    }
-
-    private BooleanExpression studyIdEq(Long studyId) {
-        return studyId != null ? study.id.eq(studyId) : null;
-    }
-
-
-    private Group createGroup(String name, int headcount, Member member) {
-        GroupCreateRequest request = new GroupCreateRequest();
-        request.setName(name);
-        request.setHeadcount(headcount);
-
-        GroupMember groupMember = GroupMember.createGroupMember(member, GroupRole.MASTER);
-
-        return Group.createGroup(request, groupMember);
-    }
-
-    private Member createMember(String username) {
-        MemberCreateRequest request = new MemberCreateRequest();
-        request.setUsername(username);
-        request.setNickname(username);
-        request.setPassword(username);
-
-        return Member.createMember(request);
     }
 }

--- a/src/test/java/seong/onlinestudy/service/TicketServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/TicketServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.repository.GroupRepository;
 import seong.onlinestudy.repository.MemberRepository;
@@ -20,6 +22,7 @@ import seong.onlinestudy.repository.TicketRepository;
 import seong.onlinestudy.request.TicketCreateRequest;
 import seong.onlinestudy.request.TicketUpdateRequest;
 
+import javax.swing.text.html.Option;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -31,6 +34,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static seong.onlinestudy.MyUtils.*;
@@ -63,10 +67,12 @@ class TicketServiceTest {
     @BeforeEach
     void testDateInit() {
         testMembers = createMembers(10, true);
-        testGroups = createGroups(testMembers, 2);
+        testGroups = createGroups(testMembers, 2, true);
+        joinMembersToGroups(testMembers, testGroups);
+
         testStudies = createStudies(2, true);
-        testStudyTickets = createTickets(STUDY, testMembers, testGroups, testStudies);
-        testRestTickets = createTickets(REST, testMembers, testGroups, testStudies);
+        testStudyTickets = createTickets(STUDY, testMembers, testGroups, testStudies, true);
+        testRestTickets = createTickets(REST, testMembers, testGroups, testStudies, true);
     }
 
     @Test
@@ -119,7 +125,7 @@ class TicketServiceTest {
     }
 
     @Test
-    @DisplayName("updateTicket_ex, 멤버 불일치")
+    @DisplayName("expiredTicket_ex, 멤버 불일치")
     void expiredTicket_ex() {
         //given
         Member memberA = MyUtils.createMember("memberA", "memberA");
@@ -144,7 +150,61 @@ class TicketServiceTest {
     }
 
     @Test
-    void getTickets_조건없음() {
+    @DisplayName("ticket 데이터 없음, 조건 없음")
+    public void getTickets_NoDataWithoutCondition() {
+        //given
+        PageImpl<Member> membersPage = new PageImpl<>(testMembers);
+        given(memberRepository.findMembersOrderByStudyTime(any(), any(), any())).willReturn(membersPage);
+
+        //when
+        TicketGetRequest request = new TicketGetRequest();
+        List<MemberTicketDto> memberTickets = ticketService.getTickets(request);
+
+        //then
+        List<Long> findMemberIds = memberTickets.stream()
+                .map(MemberTicketDto::getMemberId).collect(Collectors.toList());
+        List<Long> testMemberIds = testMembers.stream()
+                .map(Member::getId).collect(Collectors.toList());
+
+        assertThat(findMemberIds).containsExactlyInAnyOrderElementsOf(testMemberIds);
+        assertThat(memberTickets).allSatisfy(memberTicket -> {
+            assertThat(memberTicket.getActiveTicket()).isNull();
+            assertThat(memberTicket.getExpiredTickets()).isEmpty();
+            assertThat(memberTicket.getStudyTime()).isZero();
+        });
+
+    }
+
+    @Test
+    @DisplayName("ticket 데이터 없음, memberId 조건 추가")
+    void getTickets_NoDataWithCondition() {
+        //given
+        Member testMember = testMembers.get(0);
+        List<Ticket> tickets = new ArrayList<>();
+
+        given(ticketRepository.findTickets(any(), any(), anyList(), any(), any())).willReturn(tickets);
+        given(memberRepository.findById(any())).willReturn(Optional.of(testMember));
+
+        //when
+        TicketGetRequest request = new TicketGetRequest();
+        request.setMemberId(testMember.getId());
+
+        List<MemberTicketDto> memberTickets = ticketService.getTickets(request);
+
+        //then
+        List<Long> findMemberIds = memberTickets.stream().map(MemberTicketDto::getMemberId).collect(Collectors.toList());
+
+        assertThat(findMemberIds).containsExactlyInAnyOrderElementsOf(List.of(testMember.getId()));
+        assertThat(memberTickets).allSatisfy(memberTicket -> {
+
+            assertThat(memberTicket.getActiveTicket()).isNull();
+            assertThat(memberTicket.getExpiredTickets()).isEmpty();
+        });
+    }
+
+    @Test
+    @DisplayName("ticket 데이터 존재, 아무런 조건도 주어지지 않음")
+    void getTickets_DataWithoutCondition() {
         //given
         List<Ticket> tickets = new ArrayList<>();
         tickets.addAll(testStudyTickets);
@@ -152,13 +212,17 @@ class TicketServiceTest {
 
         expireTickets(tickets);
 
-        given(ticketRepository.findTickets(any(), any(), any(), any(), any())).willReturn(tickets);
+        PageRequest pageRequest = PageRequest.of(0, testMembers.size());
+        PageImpl<Member> testMembersPage = new PageImpl<>(testMembers);
+
+        given(memberRepository.findMembersOrderByStudyTime(any(), any(), any())).willReturn(testMembersPage);
+        given(ticketRepository.findTickets(any(), any(), anyList(), any(), any())).willReturn(tickets);
 
         //when
         TicketGetRequest request = new TicketGetRequest();
         Member loginMember = testMembers.get(0);
 
-        List<MemberTicketDto> memberTickets = ticketService.getTickets(request, loginMember);
+        List<MemberTicketDto> memberTickets = ticketService.getTickets(request);
 
         //then
         List<Long> testMemberIds = testMembers.stream().map(Member::getId).collect(Collectors.toList());
@@ -173,6 +237,46 @@ class TicketServiceTest {
             assertThat(memberTicket.getExpiredTickets())
                     .containsExactlyInAnyOrderElementsOf(targetTickets);
         });
+    }
+
+    @Test
+    @DisplayName("ticket 데이터 존재, groupId 조건")
+    void getTickets_DataWithCondition() {
+        //given
+        Group testGroup = testGroups.get(0);
+        List<Member> testMembersInGroup = testGroup.getGroupMembers().stream()
+                .map(GroupMember::getMember).collect(Collectors.toList());
+        List<Ticket> testTicketsInGroup = testGroup.getTickets();
+
+        expireTickets(testStudyTickets); //activeTicket 을 testRestTickets(휴식 티켓) 으로 한정한다.
+
+        given(memberRepository.findMembersInGroup(any())).willReturn(testMembersInGroup);
+        given(ticketRepository.findTickets(any(), any(), anyList(), any(), any())).willReturn(testTicketsInGroup);
+
+        //when
+        TicketGetRequest request = new TicketGetRequest();
+        request.setGroupId(testGroup.getId());
+        List<MemberTicketDto> memberTickets = ticketService.getTickets(request);
+
+        //then
+        List<Long> findMemberIds = memberTickets.stream()
+                .map(MemberTicketDto::getMemberId).collect(Collectors.toList());
+        List<Long> testMemberIds = testMembersInGroup.stream()
+                .map(Member::getId).collect(Collectors.toList());
+
+        List<Long> testActiveTicketIds = memberTickets.stream()
+                .map(MemberTicketDto::getActiveTicket)
+                .map(TicketDto::getTicketId)
+                .collect(Collectors.toList());
+
+        List<Long> testRestTicketIds = testTicketsInGroup.stream()
+                .filter(ticket -> ticket.getTicketStatus().equals(REST))
+                .map(Ticket::getId)
+                .collect(Collectors.toList());
+
+        assertThat(findMemberIds).isEqualTo(testMemberIds);
+        assertThat(testActiveTicketIds).containsExactlyInAnyOrderElementsOf(testRestTicketIds);
+
     }
 
     private List<Ticket> getTicketsOwnsByMember(List<Ticket> tickets, Long memberId) {


### PR DESCRIPTION
## 개요
티켓 목록 조회 API 사용시 아무런 인수가 주어지지 않으면 InvalidSessionException 을 던지는 부분을 수정하기 위함

## 작업 내용
티켓 목록 조회 api request 에 memberId를 포함하도록 변경.
더 이상 세션의 회원 정보를 메인 로직에 사용하지 않도록 함.
이 과정에서 사용하지 않는 인수 삭제.
이제 티켓 목록 조회 api는 아무런 인수가 주어지지 않을 때 높은 학습량을 가진 회원들의 티켓 데이터를 반환하도록 함.

## 앞으로 해결해야 하는 부분
회원의 세션 정보가 사용자의 요청에 대한 검증이 아닌, 로직에 관여하는 부분에 대해 전체적인 수정이 필요
