### PR TITLE
Feature/ticket Ticket 테이블 정규화

### DIFF
--- a/src/main/java/seong/onlinestudy/domain/Record.java
+++ b/src/main/java/seong/onlinestudy/domain/Record.java
@@ -18,14 +18,9 @@ public class Record {
     private LocalDateTime expiredTime;
     private long activeTime;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "record")
-    private Ticket ticket;
+    public static Record create() {
 
-    public static Record create(Ticket ticket) {
-        Record record = new Record();
-        ticket.setRecord(record);
-
-        return record;
+        return new Record();
     }
 
     public void update(Ticket ticket) {

--- a/src/main/java/seong/onlinestudy/domain/RestTicket.java
+++ b/src/main/java/seong/onlinestudy/domain/RestTicket.java
@@ -1,0 +1,25 @@
+package seong.onlinestudy.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@DiscriminatorValue(TicketStatus.Values.REST)
+@PrimaryKeyJoinColumn(name = "rest_ticket_id")
+public class RestTicket extends Ticket {
+
+    protected RestTicket() {
+    }
+
+    private RestTicket(Member member, Group group) {
+        super(member, group);
+    }
+
+    public static Ticket createRestTicket(Member member, Group group) {
+        RestTicket restTicket = new RestTicket(member, group);
+
+        return restTicket;
+    }
+}

--- a/src/main/java/seong/onlinestudy/domain/Study.java
+++ b/src/main/java/seong/onlinestudy/domain/Study.java
@@ -18,7 +18,7 @@ public class Study {
     private String name;
 
     @OneToMany(mappedBy = "study")
-    private List<Ticket> tickets = new ArrayList<>();
+    private List<StudyTicket> studyTickets = new ArrayList<>();
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
     private List<PostStudy> postStudies = new ArrayList<>();

--- a/src/main/java/seong/onlinestudy/domain/StudyTicket.java
+++ b/src/main/java/seong/onlinestudy/domain/StudyTicket.java
@@ -1,0 +1,36 @@
+package seong.onlinestudy.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@DiscriminatorValue(TicketStatus.Values.STUDY)
+@PrimaryKeyJoinColumn(name = "study_ticket_id")
+public class StudyTicket extends Ticket{
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    protected StudyTicket() {
+    }
+
+    private StudyTicket(Member member, Group group) {
+        super(member, group);
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
+        study.getTickets().add(this);
+    }
+
+    public static Ticket createStudyTicket(Member member, Group group, Study study) {
+        StudyTicket studyTicket = new StudyTicket(member, group);
+
+        studyTicket.setStudy(study);
+
+        return studyTicket;
+    }
+}

--- a/src/main/java/seong/onlinestudy/domain/StudyTicket.java
+++ b/src/main/java/seong/onlinestudy/domain/StudyTicket.java
@@ -23,7 +23,7 @@ public class StudyTicket extends Ticket{
 
     public void setStudy(Study study) {
         this.study = study;
-        study.getTickets().add(this);
+        study.getStudyTickets().add(this);
     }
 
     public static Ticket createStudyTicket(Member member, Group group, Study study) {

--- a/src/main/java/seong/onlinestudy/domain/Ticket.java
+++ b/src/main/java/seong/onlinestudy/domain/Ticket.java
@@ -22,9 +22,6 @@ public abstract class Ticket {
 
     private boolean expired;
 
-    @Column(name = "ticket_status", insertable = false, updatable = false)
-    private String ticketStatus;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/seong/onlinestudy/domain/Ticket.java
+++ b/src/main/java/seong/onlinestudy/domain/Ticket.java
@@ -10,7 +10,9 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-public class Ticket {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "ticket_status")
+public abstract class Ticket {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ticket_id")
@@ -18,22 +20,48 @@ public class Ticket {
 
     private LocalDateTime startTime;
 
-    @Enumerated(EnumType.STRING)
-    private TicketStatus ticketStatus;
-
     private boolean expired;
+
+    @Column(name = "ticket_status", insertable = false, updatable = false)
+    private String ticketStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id")
-    private Study study;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    protected Ticket() {
+    }
+
+    protected Ticket(Member member, Group group) {
+        this.startTime = LocalDateTime.now();
+        this.setMember(member);
+        this.setGroup(group);
+
+        Record record = Record.create();
+        this.setRecord(record);
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+        member.getTickets().add(this);
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+        group.getTickets().add(this);
+    }
+
+    public void setRecord(Record record) {
+        this.record = record;
+    }
 
     public LocalDate getDateBySetting() {
         if(startTime.getHour() < TimeConst.DAY_START) {
@@ -42,39 +70,9 @@ public class Ticket {
             return startTime.toLocalDate();
         }
     }
-    
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "record_id")
-    private Record record;
-
-    public void setRecord(Record record) {
-        this.record = record;
-    }
 
     public void expiredAndUpdateRecord() {
         expired = true;
         record.update(this);
-    }
-
-    public static Ticket createWithRecord(TicketCreateRequest request, Member member, Study study, Group group) {
-        Ticket ticket = new Ticket();
-        ticket.startTime = LocalDateTime.now();
-        ticket.ticketStatus = request.getStatus();
-        ticket.expired = false;
-
-        member.getTickets().add(ticket);
-        ticket.member = member;
-
-        if(request.getStatus() == TicketStatus.STUDY) {
-            study.getTickets().add(ticket);
-            ticket.study = study;
-        }
-
-        group.getTickets().add(ticket);
-        ticket.group = group;
-
-        Record.create(ticket);
-
-        return ticket;
     }
 }

--- a/src/main/java/seong/onlinestudy/domain/TicketStatus.java
+++ b/src/main/java/seong/onlinestudy/domain/TicketStatus.java
@@ -1,5 +1,19 @@
 package seong.onlinestudy.domain;
 
 public enum TicketStatus {
-    STUDY, REST, END
+    STUDY(Values.STUDY),
+    REST(Values.REST);
+
+    private String value;
+
+    TicketStatus(String value) {
+        if(!this.name().equals(value)) {
+            throw new IllegalArgumentException("name 값과 일치하지 않습니다.");
+        }
+    }
+
+    public static class Values {
+        public static final String STUDY = "STUDY";
+        public static final String REST = "REST";
+    }
 }

--- a/src/main/java/seong/onlinestudy/dto/MemberTicketDto.java
+++ b/src/main/java/seong/onlinestudy/dto/MemberTicketDto.java
@@ -29,7 +29,7 @@ public class MemberTicketDto {
             TicketDto ticketDto = TicketDto.from(ticket);
             if (ticket.isExpired()) {
                 memberTicket.expiredTickets.add(ticketDto);
-                if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY))
+                if(ticket instanceof StudyTicket)
                     memberTicket.studyTime += ticket.getRecord().getActiveTime();
             } else {
                 memberTicket.activeTicket = ticketDto;

--- a/src/main/java/seong/onlinestudy/dto/MemberTicketDto.java
+++ b/src/main/java/seong/onlinestudy/dto/MemberTicketDto.java
@@ -2,6 +2,7 @@ package seong.onlinestudy.dto;
 
 import lombok.Data;
 import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.Ticket;
 import seong.onlinestudy.domain.TicketStatus;
 
@@ -28,7 +29,7 @@ public class MemberTicketDto {
             TicketDto ticketDto = TicketDto.from(ticket);
             if (ticket.isExpired()) {
                 memberTicket.expiredTickets.add(ticketDto);
-                if(ticket.getTicketStatus().equals(TicketStatus.STUDY)) //학습 상태의 티켓 시간만 더함
+                if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY))
                     memberTicket.studyTime += ticket.getRecord().getActiveTime();
             } else {
                 memberTicket.activeTicket = ticketDto;

--- a/src/main/java/seong/onlinestudy/dto/RecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/RecordDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.domain.Ticket;
+import seong.onlinestudy.domain.TicketStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -22,7 +23,7 @@ public class RecordDto {
     private int memberCount;
 
     @JsonIgnore
-    private Set<Member> members = new HashSet<>();
+    private Set<Member> memberCounter = new HashSet<>();
 
     public void compareStartAndEndTime(Ticket ticket) {
         if(startTime.isAfter(ticket.getStartTime())) {
@@ -39,16 +40,14 @@ public class RecordDto {
     }
 
     public void updateMemberCount() {
-        memberCount = members.size();
+        memberCount = memberCounter.size();
     }
 
     public void addStudyTime(Ticket ticket) {
-        if(ticket.getStudy() == null) {
-            return;
+        if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY)) {
+            memberCounter.add(ticket.getMember());
+            studyTime += ticket.getRecord().getActiveTime();
         }
-
-        members.add(ticket.getMember());
-        studyTime += ticket.getRecord().getActiveTime();
     }
 
     protected RecordDto() {
@@ -68,7 +67,7 @@ public class RecordDto {
         recordDto.studyTime = ticket.getRecord().getActiveTime();
         recordDto.memberCount = 1;
 
-        recordDto.members.add(ticket.getMember());
+        recordDto.memberCounter.add(ticket.getMember());
 
         recordDto.setStartAndEndTime(ticket);
 

--- a/src/main/java/seong/onlinestudy/dto/RecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/RecordDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.Ticket;
 import seong.onlinestudy.domain.TicketStatus;
 
@@ -36,7 +37,12 @@ public class RecordDto {
 
     public void setStartAndEndTime(Ticket ticket) {
         startTime = ticket.getStartTime();
-        endTime = ticket.getRecord().getExpiredTime();
+
+        if(ticket.isExpired()) {
+            endTime = ticket.getRecord().getExpiredTime();
+        } else {
+            endTime = startTime;
+        }
     }
 
     public void updateMemberCount() {
@@ -44,7 +50,7 @@ public class RecordDto {
     }
 
     public void addStudyTime(Ticket ticket) {
-        if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY)) {
+        if(ticket instanceof StudyTicket) {
             memberCounter.add(ticket.getMember());
             studyTime += ticket.getRecord().getActiveTime();
         }

--- a/src/main/java/seong/onlinestudy/dto/StudyDto.java
+++ b/src/main/java/seong/onlinestudy/dto/StudyDto.java
@@ -3,6 +3,7 @@ package seong.onlinestudy.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import seong.onlinestudy.domain.Study;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.Ticket;
 
 import java.time.LocalDateTime;
@@ -25,7 +26,7 @@ public class StudyDto {
      * @param study Ticket 과 페치 조인한 Study
      */
     public void setStudyTime(Study study) {
-        List<Ticket> tickets = study.getTickets();
+        List<StudyTicket> studyTickets = study.getStudyTickets();
 
         long studyTime = 0;
         LocalDateTime now = LocalDateTime.now();
@@ -33,7 +34,7 @@ public class StudyDto {
         LocalDateTime startTime = now;
         LocalDateTime endTime = now;
 
-        for (Ticket ticket : tickets) {
+        for (Ticket ticket : studyTickets) {
             studyTime += ticket.getRecord().getActiveTime();
             startTime = ticket.getStartTime().isBefore(startTime) ? ticket.getStartTime() : startTime;
 

--- a/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
@@ -37,7 +37,7 @@ public class StudyRecordDto {
         recordDto.updateMemberCount();
 
         records.add(recordDto);
-        members.addAll(recordDto.getMembers());
+        members.addAll(recordDto.getMemberCounter());
     }
 
     public static StudyRecordDto from(Study study) {

--- a/src/main/java/seong/onlinestudy/dto/TicketDto.java
+++ b/src/main/java/seong/onlinestudy/dto/TicketDto.java
@@ -2,6 +2,7 @@ package seong.onlinestudy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.TicketStatus;
 import seong.onlinestudy.domain.Ticket;
 
@@ -24,7 +25,7 @@ public class TicketDto {
     public static TicketDto from(Ticket ticket) {
         TicketDto ticketDto = new TicketDto();
         ticketDto.ticketId = ticket.getId();
-        ticketDto.status = ticket.getTicketStatus();
+        ticketDto.status = TicketStatus.valueOf(ticket.getTicketStatus());
         ticketDto.expired = ticket.isExpired();
         ticketDto.activeTime = ticket.getRecord().getActiveTime();
 
@@ -33,8 +34,9 @@ public class TicketDto {
             ticketDto.endTime = ticket.getRecord().getExpiredTime();
         }
 
-        if(ticket.getStudy() != null) {
-            ticketDto.study = StudyDto.from(ticket.getStudy());
+        if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY)) {
+            StudyTicket studyTicket = (StudyTicket) ticket;
+            ticketDto.study = StudyDto.from(studyTicket.getStudy());
         }
 
         return ticketDto;

--- a/src/main/java/seong/onlinestudy/dto/TicketDto.java
+++ b/src/main/java/seong/onlinestudy/dto/TicketDto.java
@@ -2,6 +2,7 @@ package seong.onlinestudy.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
+import seong.onlinestudy.domain.RestTicket;
 import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.TicketStatus;
 import seong.onlinestudy.domain.Ticket;
@@ -25,18 +26,20 @@ public class TicketDto {
     public static TicketDto from(Ticket ticket) {
         TicketDto ticketDto = new TicketDto();
         ticketDto.ticketId = ticket.getId();
-        ticketDto.status = TicketStatus.valueOf(ticket.getTicketStatus());
         ticketDto.expired = ticket.isExpired();
         ticketDto.activeTime = ticket.getRecord().getActiveTime();
-
         ticketDto.startTime = ticket.getStartTime();
         if(ticket.isExpired()) {
             ticketDto.endTime = ticket.getRecord().getExpiredTime();
         }
 
-        if(ticket.getTicketStatus().equals(TicketStatus.Values.STUDY)) {
+        if(ticket instanceof StudyTicket) {
+            ticketDto.status = TicketStatus.STUDY;
+
             StudyTicket studyTicket = (StudyTicket) ticket;
             ticketDto.study = StudyDto.from(studyTicket.getStudy());
+        } else if(ticket instanceof RestTicket) {
+            ticketDto.status = TicketStatus.REST;
         }
 
         return ticketDto;

--- a/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
@@ -12,10 +12,6 @@ import java.util.List;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
-    @Query("select new seong.onlinestudy.dto.GroupMemberCountDto(g.id, count(gm.id)) from Group g join GroupMember gm" +
-            " where g in :groups group by g.id")
-    List<GroupMemberCountDto> countMemberInGroups(@Param("groups") List<Group> groups);
-
     @Query("select gm from GroupMember gm" +
             " join fetch gm.group g" +
             " join fetch gm.member m" +

--- a/src/main/java/seong/onlinestudy/repository/GroupRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupRepositoryImpl.java
@@ -16,6 +16,7 @@ import static seong.onlinestudy.domain.QGroup.*;
 import static seong.onlinestudy.domain.QGroupMember.groupMember;
 import static seong.onlinestudy.domain.QRecord.record;
 import static seong.onlinestudy.domain.QStudy.study;
+import static seong.onlinestudy.domain.QStudyTicket.studyTicket;
 import static seong.onlinestudy.domain.QTicket.ticket;
 
 public class GroupRepositoryImpl implements GroupRepositoryCustom{
@@ -45,7 +46,8 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom{
                 .selectFrom(group)
                 .leftJoin(group.tickets, ticket)
                 .leftJoin(ticket.record, record)
-                .leftJoin(ticket.study, study)
+                .join(studyTicket).on(studyTicket.eq(ticket))
+                .join(studyTicket.study, study)
                 .join(group.groupMembers, groupMember)
                 .where(categoryEq(category), nameContains(search), studyIdsIn(studyIds))
                 .groupBy(group.id)
@@ -58,7 +60,8 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom{
                 .select(group.count())
                 .from(group)
                 .leftJoin(group.tickets, ticket)
-                .leftJoin(ticket.study, study)
+                .join(studyTicket).on(studyTicket.eq(ticket))
+                .join(studyTicket.study, study)
                 .where(categoryEq(category), nameContains(search), studyIdsIn(studyIds))
                 .fetchOne();
 

--- a/src/main/java/seong/onlinestudy/repository/PostRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/PostRepository.java
@@ -18,6 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Query("select p from Post p left join fetch p.member m left join fetch p.group g where p.id=:postId")
     Optional<Post> findByIdWithMemberAndGroup(@Param("postId") Long postId);
 
-    @Query("select p from Post p left join fetch p.postStudies ps join fetch ps.study s where p.id=:postId")
+    @Query("select p from Post p left join fetch p.postStudies ps left join fetch ps.study s where p.id=:postId")
     Optional<Post> findByIdWithStudies(@Param("postId") Long postId);
 }

--- a/src/main/java/seong/onlinestudy/repository/StudyRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/StudyRepository.java
@@ -24,7 +24,7 @@ public interface StudyRepository extends JpaRepository<Study, Long>, StudyReposi
      * @return Study 리스트를 반환
      */
     @Query("select s from Study s" +
-            " join s.tickets t on t.member.id = :memberId and t.startTime >= :startTime and t.startTime < :endTime" +
+            " join s.studyTickets t on t.member.id = :memberId and t.startTime >= :startTime and t.startTime < :endTime" +
             " join t.record r" +
             " group by s.id" +
             " order by sum(r.activeTime) desc")

--- a/src/main/java/seong/onlinestudy/repository/StudyRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/StudyRepository.java
@@ -13,22 +13,4 @@ import java.util.Optional;
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
 
     Optional<Study> findByName(String name);
-    Page<Study> findAllByNameContains(String name, Pageable pageable);
-
-    /**
-     * Study 엔티티로부터 ticket 의 member 가 일치하고, startTime 이상, endTime 미만인 Ticket 을 조인한 스터디 목록을 조회한다.
-     * @param memberId ticket 의 member
-     * @param startTime ticket 의 startTime 이 startTime 이상
-     * @param endTime ticket 의 startTime 이 endTime 미만
-     * @param pageable
-     * @return Study 리스트를 반환
-     */
-    @Query("select s from Study s" +
-            " join s.studyTickets t on t.member.id = :memberId and t.startTime >= :startTime and t.startTime < :endTime" +
-            " join t.record r" +
-            " group by s.id" +
-            " order by sum(r.activeTime) desc")
-    Page<Study> findStudiesByMember(@Param("memberId") Long memberId, @Param("startTime") LocalDateTime startTime,
-                                    @Param("endTime") LocalDateTime endTime, Pageable pageable);
-
 }

--- a/src/main/java/seong/onlinestudy/repository/StudyRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/StudyRepositoryImpl.java
@@ -17,6 +17,7 @@ import static seong.onlinestudy.domain.QGroup.group;
 import static seong.onlinestudy.domain.QMember.member;
 import static seong.onlinestudy.domain.QRecord.record;
 import static seong.onlinestudy.domain.QStudy.study;
+import static seong.onlinestudy.domain.QStudyTicket.studyTicket;
 import static seong.onlinestudy.domain.QTicket.ticket;
 
 public class StudyRepositoryImpl implements StudyRepositoryCustom{
@@ -38,7 +39,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom{
                         ticket.record.activeTime.sum().as("studyTime")
                 ))
                 .from(study)
-                .join(study.tickets, ticket)
+                .join(study.studyTickets, studyTicket)
                 .join(ticket.record, record)
                 .join(ticket.group, group)
                 .where(group.in(groups))
@@ -51,7 +52,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom{
     public Page<Study> findStudies(Long memberId, Long groupId, String search, LocalDateTime startTime, LocalDateTime endTime, Pageable pageable) {
         List<Study> result = query
                 .selectFrom(study)
-                .leftJoin(study.tickets, ticket)
+                .join(study.studyTickets, studyTicket)
                 .join(ticket.member, member)
                 .join(ticket.record, record)
                 .join(ticket.group, group)
@@ -66,7 +67,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom{
         Long count = query
                 .select(study.id.count())
                 .from(study)
-                .leftJoin(study.tickets, ticket)
+                .join(study.studyTickets, studyTicket)
                 .join(ticket.member, member)
                 .join(ticket.group, group)
                 .where(memberIdEq(memberId), groupIdEq(groupId), studyNameContains(search))

--- a/src/main/java/seong/onlinestudy/repository/StudyTicketRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/StudyTicketRepositoryCustom.java
@@ -1,0 +1,11 @@
+package seong.onlinestudy.repository;
+
+import seong.onlinestudy.domain.StudyTicket;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StudyTicketRepositoryCustom {
+
+    List<StudyTicket> findStudyTickets(Long memberId, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime);
+}

--- a/src/main/java/seong/onlinestudy/repository/TicketRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepository.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom {
+public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRepositoryCustom, StudyTicketRepositoryCustom {
 
     Optional<Ticket> findByMemberAndExpiredFalse(Member member);
 
@@ -24,7 +24,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRep
      */
     @Query("select t from Ticket t" +
             " join t.member m on m = :member" +
-            " left join fetch t.study s" +
             " join fetch t.record r" +
             " where t.startTime >= :startTime and t.startTime < :endTime")
     List<Ticket> findTickets(@Param("member") Member member,
@@ -40,7 +39,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketRep
      */
     @Query("select t from Ticket t" +
             " join fetch t.member m" +
-            " join fetch t.study s" +
             " join fetch t.record r" +
             " join m.groupMembers gm on gm.group.id = :groupId" +
             " where t.startTime >= :startTime and t.startTime < :endTime" +

--- a/src/main/java/seong/onlinestudy/repository/TicketRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepositoryCustom.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface TicketRepositoryCustom {
 
-    List<Ticket> findTickets(Long studyId, Long groupId, List<Long> memberIds, LocalDateTime startTime, LocalDateTime endTime);
-    List<Ticket> findTickets(Long studyId, Long groupId, Long memberId, LocalDateTime startTime, LocalDateTime endTime);
+    List<Ticket> findTickets(List<Long> memberIds, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime);
+    List<Ticket> findTickets(Long memberId, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/seong/onlinestudy/repository/TicketRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/TicketRepositoryImpl.java
@@ -2,6 +2,7 @@ package seong.onlinestudy.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.domain.Ticket;
 
 import javax.persistence.EntityManager;
@@ -12,9 +13,10 @@ import static seong.onlinestudy.domain.QGroup.group;
 import static seong.onlinestudy.domain.QMember.member;
 import static seong.onlinestudy.domain.QRecord.record;
 import static seong.onlinestudy.domain.QStudy.study;
+import static seong.onlinestudy.domain.QStudyTicket.studyTicket;
 import static seong.onlinestudy.domain.QTicket.ticket;
 
-public class TicketRepositoryImpl implements TicketRepositoryCustom{
+public class TicketRepositoryImpl implements TicketRepositoryCustom, StudyTicketRepositoryCustom{
 
     JPAQueryFactory query;
 
@@ -23,13 +25,14 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom{
     }
 
     @Override
-    public List<Ticket> findTickets(Long studyId, Long groupId, List<Long> memberIds, LocalDateTime startTime, LocalDateTime endTime) {
+    public List<Ticket> findTickets(List<Long> memberIds, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime) {
         List<Ticket> findTickets = query
                 .selectFrom(ticket)
                 .join(ticket.group, group)
-                .leftJoin(ticket.study, study).fetchJoin()
                 .join(ticket.member, member).fetchJoin()
                 .join(ticket.record, record).fetchJoin()
+                .leftJoin(studyTicket).on(studyTicket.eq(ticket))
+                .join(studyTicket.study, study).fetchJoin()
                 .where(studyIdEq(studyId), groupIdEq(groupId), memberIdsIn(memberIds),
                         ticket.startTime.goe(startTime), ticket.startTime.lt(endTime))
                 .orderBy(study.id.asc(), ticket.startTime.asc())
@@ -39,19 +42,33 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom{
     }
 
     @Override
-    public List<Ticket> findTickets(Long studyId, Long groupId, Long memberId, LocalDateTime startTime, LocalDateTime endTime) {
+    public List<Ticket> findTickets(Long memberId, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime) {
         List<Ticket> findTickets = query
                 .selectFrom(ticket)
                 .join(ticket.group, group)
-                .leftJoin(ticket.study, study).fetchJoin()
                 .join(ticket.member, member).fetchJoin()
                 .join(ticket.record, record).fetchJoin()
+                .leftJoin(studyTicket).on(studyTicket.eq(ticket))
+                .join(studyTicket.study, study).fetchJoin()
                 .where(studyIdEq(studyId), groupIdEq(groupId), memberIdEq(memberId),
                         ticket.startTime.goe(startTime), ticket.startTime.lt(endTime))
                 .orderBy(study.id.asc(), ticket.startTime.asc())
                 .fetch();
 
         return findTickets;
+    }
+
+    @Override
+    public List<StudyTicket> findStudyTickets(Long memberId, Long groupId, Long studyId, LocalDateTime startTime, LocalDateTime endTime) {
+        return query
+                .selectFrom(studyTicket)
+                .join(studyTicket.member, member).fetchJoin()
+                .join(studyTicket.group, group)
+                .join(studyTicket.study, study).fetchJoin()
+                .join(studyTicket.record, record).fetchJoin()
+                .where(memberIdEq(memberId), groupIdEq(groupId), studyIdEq(studyId),
+                        studyTicket.startTime.goe(startTime), studyTicket.startTime.lt(endTime))
+                .fetch();
     }
 
     private BooleanExpression memberIdsIn(List<Long> memberIds) {
@@ -69,4 +86,5 @@ public class TicketRepositoryImpl implements TicketRepositoryCustom{
     private BooleanExpression studyIdEq(Long studyId) {
         return studyId != null ? study.id.eq(studyId) : null;
     }
+
 }

--- a/src/main/java/seong/onlinestudy/request/PostCreateRequest.java
+++ b/src/main/java/seong/onlinestudy/request/PostCreateRequest.java
@@ -20,5 +20,7 @@ public class PostCreateRequest {
     private PostCategory category;
 
     private List<Long> studyIds;
+
+    @NotNull(message = "그룹은 필수로 지정되어야 합니다.")
     private Long groupId;
 }

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -60,16 +60,14 @@ public class PostService {
 
         Post post = Post.createPost(request, member);
 
-        if(request.getGroupId() != null) {
-            Group group = groupRepository.findGroupWithMembers(request.getGroupId())
-                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 그룹입니다."));
+        Group group = groupRepository.findGroupWithMembers(request.getGroupId())
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 그룹입니다."));
 
-            Optional<GroupMember> groupMember = group.getGroupMembers().stream()
-                    .filter(gm -> gm.getMember().getId().equals(member.getId())).findFirst();
-            groupMember.orElseThrow(() -> new PermissionControlException("접근 권한이 없습니다."));
+        Optional<GroupMember> groupMember = group.getGroupMembers().stream()
+                .filter(gm -> gm.getMember().getId().equals(member.getId())).findFirst();
+        groupMember.orElseThrow(() -> new PermissionControlException("접근 권한이 없습니다."));
 
-            post.setGroup(group);
-        }
+        post.setGroup(group);
 
         if(request.getStudyIds() != null) {
             List<Study> studies = studyRepository.findAllById(request.getStudyIds());

--- a/src/main/java/seong/onlinestudy/service/RecordService.java
+++ b/src/main/java/seong/onlinestudy/service/RecordService.java
@@ -3,6 +3,7 @@ package seong.onlinestudy.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import seong.onlinestudy.TimeConst;
+import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.dto.RecordDto;
 import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.request.RecordsGetRequest;
@@ -32,8 +33,8 @@ public class RecordService {
         LocalDateTime startTime = request.getStartDate().atStartOfDay().plusHours(TimeConst.DAY_START);
         LocalDateTime endTime = startTime.plusDays(request.getDays());
 
-        List<Ticket> findTickets = ticketRepository
-                .findTickets(request.getStudyId(), request.getGroupId(), request.getMemberId(), startTime, endTime);
+        List<StudyTicket> findTickets = ticketRepository
+                .findStudyTickets(request.getMemberId(), request.getGroupId(), request.getStudyId(), startTime, endTime);
 
         Map<Study, List<Ticket>> ticketsGroupByStudy = getTicketsGroupByStudy(findTickets);
 
@@ -50,9 +51,9 @@ public class RecordService {
         return studyRecordDtos;
     }
 
-    private Map<Study, List<Ticket>> getTicketsGroupByStudy(List<Ticket> findTickets) {
+    private Map<Study, List<Ticket>> getTicketsGroupByStudy(List<StudyTicket> findTickets) {
         Map<Study, List<Ticket>> ticketsGroupByStudy = new HashMap<>();
-        for (Ticket findTicket : findTickets) {
+        for (StudyTicket findTicket : findTickets) {
             Study findStudy = findTicket.getStudy();
 
             List<Ticket> filteredTickets = ticketsGroupByStudy.getOrDefault(findStudy, new ArrayList<>());

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -209,7 +209,7 @@ public class MyUtils {
         }
     }
 
-    public static List<Ticket> createStudyTickets(List<Member> members, List<Group> groups, List<Study> studies) {
+    public static List<Ticket> createStudyTickets(List<Member> members, List<Group> groups, List<Study> studies, boolean setId) {
         List<Ticket> tickets = new ArrayList<>();
 
         Map<Member, Ticket> memberActiveTicket = new HashMap<>();
@@ -221,8 +221,14 @@ public class MyUtils {
                     groups.get(random.nextInt(groups.size())),
                     studies.get(random.nextInt(studies.size()))
             );
+
+            if(setId) {
+                setField(ticket, "id", (long) i);
+            }
+
             tickets.add(ticket);
 
+            //회원의 활성 상태 티켓이 존재한다면 만료시킨다.
             if(memberActiveTicket.containsKey(targetMember)) {
                 Ticket activeTicket = memberActiveTicket.get(targetMember);
                 activeTicket.expiredAndUpdateRecord();
@@ -232,7 +238,7 @@ public class MyUtils {
         return tickets;
     }
 
-    public static List<Ticket> createRestTickets(List<Member> members, List<Group> groups) {
+    public static List<Ticket> createRestTickets(List<Member> members, List<Group> groups, boolean setId) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
             Ticket ticket = createRestTicket(
@@ -240,6 +246,7 @@ public class MyUtils {
                     groups.get(random.nextInt(groups.size()))
             );
             tickets.add(ticket);
+            setField(ticket, "id", (long)i);
         }
         return tickets;
     }

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -7,14 +7,12 @@ import seong.onlinestudy.request.MemberCreateRequest;
 import seong.onlinestudy.request.StudyCreateRequest;
 import seong.onlinestudy.request.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.springframework.test.util.ReflectionTestUtils.setField;
-import static seong.onlinestudy.domain.TicketStatus.END;
-import static seong.onlinestudy.domain.TicketStatus.STUDY;
-
 public class MyUtils {
+
+    private static final Random random = new Random();
 
     public static Member createMember(String username, String password) {
         MemberCreateRequest request = new MemberCreateRequest();
@@ -57,14 +55,15 @@ public class MyUtils {
         return groups;
     }
 
-    public static Ticket createTicket(TicketStatus status, Member member, Study study, Group group) {
-        TicketCreateRequest request = new TicketCreateRequest();
-        request.setStatus(status);
-        return Ticket.createWithRecord(request, member, study, group);
+    public static Ticket createRestTicket(Member member, Group group) {
+        return RestTicket.createRestTicket(member, group);
+    }
+
+    public static Ticket createStudyTicket(Member member, Group group, Study study) {
+        return StudyTicket.createStudyTicket(member, group, study);
     }
 
     public static void setTicketEnd(Ticket ticket, long seconds) {
-        setField(ticket, "ticketStatus", END);
         setField(ticket.getRecord(), "activeTime", seconds);
         setField(ticket.getRecord(), "expiredTime", ticket.getStartTime().plusSeconds(seconds));
     }
@@ -169,8 +168,8 @@ public class MyUtils {
     public static List<Post> createPosts(List<Member> members, List<Group> groups, int endId, boolean setId) {
         List<Post> posts = new ArrayList<>();
         for(int i=0; i<endId; i++) {
-            Post post = createPost("testPost" + i, "testPost" + i, PostCategory.CHAT, members.get(i%members.size()));
-            post.setGroup(groups.get(i%groups.size()));
+            Post post = createPost("testPost" + i, "testPost" + i, PostCategory.CHAT, members.get(random.nextInt(members.size())));
+            post.setGroup(groups.get(random.nextInt(groups.size())));
             posts.add(post);
 
             if(setId) {
@@ -210,20 +209,46 @@ public class MyUtils {
         }
     }
 
-    public static List<Ticket> createTickets(TicketStatus status, List<Member> members, List<Group> groups, List<Study> studies) {
+    public static List<Ticket> createStudyTickets(List<Member> members, List<Group> groups, List<Study> studies) {
+        List<Ticket> tickets = new ArrayList<>();
+
+        Map<Member, Ticket> memberActiveTicket = new HashMap<>();
+        for(int i=0; i<members.size()*4; i++) {
+            Member targetMember = members.get(random.nextInt(members.size()));
+
+            Ticket ticket = createStudyTicket(
+                    targetMember,
+                    groups.get(random.nextInt(groups.size())),
+                    studies.get(random.nextInt(studies.size()))
+            );
+            tickets.add(ticket);
+
+            if(memberActiveTicket.containsKey(targetMember)) {
+                Ticket activeTicket = memberActiveTicket.get(targetMember);
+                activeTicket.expiredAndUpdateRecord();
+            }
+            memberActiveTicket.put(targetMember, ticket);
+        }
+        return tickets;
+    }
+
+    public static List<Ticket> createRestTickets(List<Member> members, List<Group> groups) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createTicket(status, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
+            Ticket ticket = createRestTicket(
+                    members.get(random.nextInt(members.size())),
+                    groups.get(random.nextInt(groups.size()))
+            );
             tickets.add(ticket);
         }
         return tickets;
     }
 
-    public static List<Ticket> createTickets(TicketStatus status, List<Member> members, List<Group> groups,
-                                             List<Study> studies, boolean setId) {
+    public static List<Ticket> createStudyTickets(TicketStatus status, List<Member> members, List<Group> groups,
+                                                  List<Study> studies, boolean setId) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createTicket(status, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
+            Ticket ticket = createStudyTicket(members.get(i), groups.get(i % groups.size()), studies.get(i % studies.size()));
             tickets.add(ticket);
             setField(ticket, "id", (long)i);
         }
@@ -233,7 +258,7 @@ public class MyUtils {
     public static List<Ticket> createEndTickets(List<Member> members, List<Group> groups, List<Study> studies, long studyTime) {
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createTicket(STUDY, members.get(i), studies.get(i % studies.size()), groups.get(i % groups.size()));
+            Ticket ticket = createStudyTicket(members.get(i), groups.get(i % groups.size()), studies.get(i % studies.size()));
             tickets.add(ticket);
         }
         for (Ticket ticket : tickets) {

--- a/src/test/java/seong/onlinestudy/api/RecordApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/RecordApiTest.java
@@ -1,13 +1,11 @@
 package seong.onlinestudy.api;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -15,7 +13,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.repository.GroupRepository;
 import seong.onlinestudy.repository.MemberRepository;
@@ -64,7 +61,7 @@ public class RecordApiTest {
         studies = createStudies(10);
         tickets = new ArrayList<>();
         for(int i=0; i<50; i++) {
-            tickets.add(createTicket(TicketStatus.STUDY, members.get(i), studies.get(i % 10), groups.get(i % 10)));
+            tickets.add(createStudyTicket(members.get(i), groups.get(i % 10), studies.get(i % 10)));
         }
 
         memberRepository.saveAll(members);

--- a/src/test/java/seong/onlinestudy/api/TicketApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/TicketApiTest.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
@@ -16,16 +15,12 @@ import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.repository.StudyRepository;
 import seong.onlinestudy.repository.TicketRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static seong.onlinestudy.MyUtils.*;
-import static seong.onlinestudy.MyUtils.createTicket;
-import static seong.onlinestudy.domain.TicketStatus.REST;
-import static seong.onlinestudy.domain.TicketStatus.STUDY;
 
 @Transactional
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -54,9 +49,9 @@ public class TicketApiTest {
         }
 
         List<Study> studies = createStudies(2);
-        List<Ticket> studyTicketsToExpire = createTickets(STUDY, members, groups, studies);
-        List<Ticket> restTicketsToExpire = createTickets(REST, members, groups, studies);
-        List<Ticket> studyTickets = createTickets(STUDY, members, groups, studies);
+        List<Ticket> studyTicketsToExpire = createStudyTickets(members, groups, studies, false);
+        List<Ticket> restTicketsToExpire = createStudyTickets(members, groups, studies, false);
+        List<Ticket> studyTickets = createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);

--- a/src/test/java/seong/onlinestudy/controller/LoginControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/LoginControllerTest.java
@@ -3,6 +3,7 @@ package seong.onlinestudy.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -35,7 +36,7 @@ class LoginControllerTest {
     void init() {
         MemberCreateRequest request = new MemberCreateRequest();
         request.setUsername("test1234");
-        request.setPassword("test1234");
+        request.setPassword("test1234!");
         request.setNickname("test");
 
         Member member = Member.createMember(request);
@@ -43,11 +44,14 @@ class LoginControllerTest {
     }
 
     @Test
+    @DisplayName("로그인 성공")
     void 로그인성공() throws Exception {
+        //given
         LoginRequest request = new LoginRequest();
         request.setUsername("test1234");
-        request.setPassword("test1234");
+        request.setPassword("test1234!");
 
+        //when
         mvc.perform(post("/api/v1/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))

--- a/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
@@ -8,16 +8,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.SessionConst;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.MemberTicketDto;
-import seong.onlinestudy.dto.TicketDto;
 import seong.onlinestudy.request.TicketGetRequest;
 import seong.onlinestudy.request.TicketUpdateRequest;
 import seong.onlinestudy.service.TicketService;
@@ -62,14 +59,13 @@ class TicketControllerTest {
         Member member = MyUtils.createMember("member", "member");
         Study study = createStudy("study");
         Group group = createGroup("group", 30, member);
-        Ticket ticket = createTicket(TicketStatus.STUDY, member, study, group);
+        Ticket ticket = createStudyTicket(member, group, study);
 
         session.setAttribute(SessionConst.LOGIN_MEMBER, member);
         given(ticketService.expireTicket(any(), any())).willReturn(1L);
 
         //when
         TicketUpdateRequest request = new TicketUpdateRequest();
-        request.setStatus(TicketStatus.END);
         mvc.perform(post("/api/v1/ticket/1")
                         .content(mapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -94,9 +90,9 @@ class TicketControllerTest {
         setField(study, "id", 1L);
         setField(group, "id", 1L);
 
-        Ticket targetTicket = createTicket(TicketStatus.STUDY, member, study, group);
-        Ticket expiredStudyTicket = createTicket(TicketStatus.STUDY, member, study, group);
-        Ticket expiredRestTicket = createTicket(TicketStatus.REST, member, study, group);
+        Ticket targetTicket = createStudyTicket(member, group, study);
+        Ticket expiredStudyTicket = createStudyTicket(member, group, study);
+        Ticket expiredRestTicket = createStudyTicket(member, group, study);
         setField(expiredStudyTicket, "id", 1L);
         setField(expiredRestTicket, "id", 2L);
         setField(targetTicket, "id", 3L);

--- a/src/test/java/seong/onlinestudy/controller/TicketMessageControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketMessageControllerTest.java
@@ -1,7 +1,6 @@
 package seong.onlinestudy.controller;
 
 import lombok.Getter;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,15 +19,12 @@ import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
-import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.TicketDto;
 import seong.onlinestudy.repository.GroupRepository;
 import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.repository.StudyRepository;
 import seong.onlinestudy.repository.TicketRepository;
-import seong.onlinestudy.request.GroupCreateRequest;
-import seong.onlinestudy.request.TicketCreateRequest;
 import seong.onlinestudy.websocket.TicketMessage;
 
 import javax.persistence.EntityManager;
@@ -103,7 +99,7 @@ class TicketMessageControllerTest {
         groupRepository.save(group);
         Study study = createStudy("study");
         studyRepository.save(study);
-        Ticket ticket = createTicket(TicketStatus.STUDY, member, study, group);
+        Ticket ticket = createStudyTicket(member, group, study);
         ticketRepository.save(ticket);
         em.flush();
         em.clear();

--- a/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
@@ -1,4 +1,4 @@
-package seong.onlinestudy.service;
+package seong.onlinestudy.repository;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/seong/onlinestudy/repository/GroupMemberRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/GroupMemberRepositoryTest.java
@@ -36,20 +36,6 @@ class GroupMemberRepositoryTest {
     GroupRepository groupRepository;
 
     @Test
-    void countMemberInGroups() {
-        List<Member> members = createMembers(50);
-        memberRepository.saveAll(members);
-
-        List<Group> groups = new ArrayList<>();
-        for(int i=0; i<10; i++) {
-            groups.add(MyUtils.createGroup("테스트그룹" + i, 30, members.get(i)));
-        }
-        groupRepository.saveAll(groups);
-
-    }
-
-    @Test
-    @DisplayName("그룹 목록의 그룹장 리스트를 조회")
     void findGroupMasters() {
         //given
         List<Member> masters = createMembers(10);
@@ -69,12 +55,6 @@ class GroupMemberRepositoryTest {
         }
 
         //when
-//        List<GroupMember> result = em.createQuery("select gm from GroupMember gm" +
-//                        " join fetch gm.group g" +
-//                        " join fetch gm.member m" +
-//                        " where gm.role='MASTER' and g in :groups", GroupMember.class)
-//                .setParameter("groups", groups)
-//                .getResultList();
         List<GroupMember> result = groupMemberRepository.findGroupMasters(groups);
 
         //then

--- a/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
@@ -16,6 +16,7 @@ import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.request.GroupCreateRequest;
 import seong.onlinestudy.request.MemberCreateRequest;
+import seong.onlinestudy.request.OrderBy;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -50,9 +51,16 @@ class GroupRepositoryTest {
         }
     }
 
+    List<Member> members;
+    List<Group> groups;
+
     @BeforeEach
     void init() {
+        members = MyUtils.createMembers(30);
+        groups = MyUtils.createGroups(members, 4);
 
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
     }
 
     @Test
@@ -94,46 +102,18 @@ class GroupRepositoryTest {
     }
 
     @Test
-    void getGroupMember() {
-        //given
-
-
-        //when
-        Group group = groupRepository.findAll().get(0);
-
-        //then
-        log.info("groupMembers={}",group.getGroupMembers());
-        List<GroupMember> groupMembers = group.getGroupMembers();
-        assertThat(groupMembers.size()).isEqualTo(2);
-    }
-
-    @Test
     void getGroups() {
         //given
-        List<Member> members = MyUtils.createMembers(50);
-        memberRepository.saveAll(members);
-
-        List<Group> groups = new ArrayList<>();
-        for(int i=0; i<20; i++) {
-            groups.add(MyUtils.createGroup("테스트그룹" + 1, 30, members.get(i)));
-        }
-        groupRepository.saveAll(groups);
-
-        PageRequest request = PageRequest.of(0, 10);
+        PageRequest request = PageRequest.of(0, groups.size());
 
         //when
-        Page<Group> findGroups = groupRepository.findGroups(request, null, null, null, null);
+        Page<Group> findGroups = groupRepository.findGroups(request,
+                null, null, null, OrderBy.CREATEDAT);
 
         //then
-        Group[] groupArr = new Group[10];
-        for(int i=0; i<10; i++) {
-            groupArr[i] = groups.get(i);
-        }
-
-        assertThat(findGroups.getContent()).containsExactly(groupArr);
-        assertThat(findGroups.getSize()).isEqualTo(10);
+        assertThat(findGroups.getContent())
+                .containsExactlyInAnyOrderElementsOf(groups);
     }
-
 
     private BooleanExpression categoryEq(GroupCategory category) {
         return category != null ? group.category.eq(category) : null;

--- a/src/test/java/seong/onlinestudy/repository/MemberRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/MemberRepositoryTest.java
@@ -40,8 +40,8 @@ class MemberRepositoryTest {
         testStudies = createStudies(2);
         joinMembersToGroups(testMembers, testGroups);
 
-        testStudyTickets = createStudyTickets(testMembers, testGroups, testStudies);
-        testRestTickets = createStudyTickets(testMembers, testGroups, testStudies);
+        testStudyTickets = createStudyTickets(testMembers, testGroups, testStudies, false);
+        testRestTickets = createStudyTickets(testMembers, testGroups, testStudies, false);
 
         memberRepository.saveAll(testMembers);
         groupRepository.saveAll(testGroups);

--- a/src/test/java/seong/onlinestudy/repository/MemberRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/MemberRepositoryTest.java
@@ -1,25 +1,18 @@
 package seong.onlinestudy.repository;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
-import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
-import seong.onlinestudy.dto.GroupMemberDto;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static seong.onlinestudy.MyUtils.*;
 
 @DataJpaTest
@@ -47,8 +40,8 @@ class MemberRepositoryTest {
         testStudies = createStudies(2);
         joinMembersToGroups(testMembers, testGroups);
 
-        testStudyTickets = createTickets(TicketStatus.STUDY, testMembers, testGroups, testStudies);
-        testRestTickets = createTickets(TicketStatus.REST, testMembers, testGroups, testStudies);
+        testStudyTickets = createStudyTickets(testMembers, testGroups, testStudies);
+        testRestTickets = createStudyTickets(testMembers, testGroups, testStudies);
 
         memberRepository.saveAll(testMembers);
         groupRepository.saveAll(testGroups);

--- a/src/test/java/seong/onlinestudy/repository/PostStudyRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostStudyRepositoryTest.java
@@ -1,5 +1,6 @@
 package seong.onlinestudy.repository;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static seong.onlinestudy.MyUtils.*;
 
 @DataJpaTest
 class PostStudyRepositoryTest {
@@ -24,6 +26,26 @@ class PostStudyRepositoryTest {
     StudyRepository studyRepository;
     @Autowired
     PostStudyRepository postStudyRepository;
+
+    List<Member> members;
+    List<Group> groups;
+    List<Study> studies;
+    List<Post> posts;
+
+    @BeforeEach
+    void init() {
+        members = createMembers(30);
+        groups = createGroups(members, 3);
+
+        joinMembersToGroups(members, groups);
+
+        studies = createStudies(3);
+        posts = createPosts(members, groups, 30, false);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        postRepository.saveAll(posts);
+    }
 
     @Test
     void findStudiesWherePost() {

--- a/src/test/java/seong/onlinestudy/repository/RecordRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/RecordRepositoryTest.java
@@ -47,9 +47,9 @@ class RecordRepositoryTest {
         }
         List<Ticket> tickets = new ArrayList<>();
         for(int i=0; i<20; i++) {
-            Ticket ticket = createTicket(TicketStatus.STUDY, members.get(i),
-                    studies.get(i % studies.size()),
-                    groups.get(i % groups.size()));
+            Ticket ticket = createStudyTicket(members.get(i),
+                    groups.get(i % groups.size()), studies.get(i % studies.size())
+            );
 
             ReflectionTestUtils.setField(ticket, "startTime", LocalDateTime.now().plusMinutes(i));
 
@@ -65,18 +65,8 @@ class RecordRepositoryTest {
         LocalDateTime endTime = LocalDateTime.now().plusHours(1);
         ZoneOffset offset = ZoneOffset.of("+00:00");
         List<Long> studyIds = tickets.stream().map(Ticket::getId).collect(Collectors.toList());
-//        recordRepository.updateRecordsWhereExpiredFalse(endTime, endTime.toEpochSecond(offset));
         em.clear();
         em.flush();
-/*        em.createNativeQuery("update Record r" +
-                        " set r.expired_time=:expiredTime," +
-                        " r.active_time=:expiredTimeToSeconds - datediff('second', '1970-01-01', (" +
-                        "select t.start_time from Ticket t where t.record_id=r.record_id))" +
-                        " where r.record_id in (select t.record_id from Ticket t where t.ticket_id in :ticketIds)")
-                .setParameter("expiredTime", endTime)
-                .setParameter("expiredTimeToSeconds", endTime.toEpochSecond(offset))
-                .setParameter("ticketIds", tickets.stream().map(Ticket::getId).collect(Collectors.toList()))
-                .executeUpdate();*/
         recordRepository.updateRecordsWhereExpiredFalse(endTime, endTime.toEpochSecond(offset),
                 studyIds);
 

--- a/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
@@ -1,11 +1,7 @@
 package seong.onlinestudy.repository;
 
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.Data;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -17,19 +13,12 @@ import seong.onlinestudy.domain.*;
 import javax.persistence.EntityManager;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static seong.onlinestudy.MyUtils.*;
-import static seong.onlinestudy.domain.QGroup.group;
-import static seong.onlinestudy.domain.QGroupMember.groupMember;
-import static seong.onlinestudy.domain.QMember.member;
-import static seong.onlinestudy.domain.QRecord.record;
-import static seong.onlinestudy.domain.QStudy.study;
-import static seong.onlinestudy.domain.QStudyTicket.studyTicket;
 
 @DataJpaTest
 public class StudyRepositoryCustomTest {
@@ -63,7 +52,7 @@ public class StudyRepositoryCustomTest {
         joinMembersToGroups(members, groups);
 
         studies = createStudies(3);
-        studyTickets = createStudyTickets(members, groups, studies);
+        studyTickets = createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);
@@ -79,7 +68,7 @@ public class StudyRepositoryCustomTest {
         MyUtils.joinMembersToGroups(members, groups);
 
         List<Study> studies = createStudies(5);
-        List<Ticket> tickets = createStudyTickets(members, groups, studies);
+        List<Ticket> tickets = createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);
@@ -107,7 +96,7 @@ public class StudyRepositoryCustomTest {
         MyUtils.joinMembersToGroups(members, groups);
 
         List<Study> studies = createStudies(5);
-        List<Ticket> tickets = createStudyTickets(members, groups, studies);
+        List<Ticket> tickets = createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);

--- a/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.Data;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -18,6 +19,7 @@ import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -27,7 +29,7 @@ import static seong.onlinestudy.domain.QGroupMember.groupMember;
 import static seong.onlinestudy.domain.QMember.member;
 import static seong.onlinestudy.domain.QRecord.record;
 import static seong.onlinestudy.domain.QStudy.study;
-import static seong.onlinestudy.domain.QTicket.ticket;
+import static seong.onlinestudy.domain.QStudyTicket.studyTicket;
 
 @DataJpaTest
 public class StudyRepositoryCustomTest {
@@ -45,79 +47,39 @@ public class StudyRepositoryCustomTest {
     @Autowired
     TicketRepository ticketRepository;
 
+    List<Member> members;
+    List<Group> groups;
+    List<Study> studies;
+    List<Ticket> studyTickets;
+
+
     @BeforeEach
     void init() {
         query = new JPAQueryFactory(em);
 
-        Member member = createMember("member", "member");
-        Group group = createGroup("테스트그룹", 30, member);
-        memberRepository.save(member);
-        groupRepository.save(group);
+        members = createMembers(50);
+        groups = createGroups(members, 10);
 
-        Study study = createStudy("테스트스터디");
-        studyRepository.save(study);
+        joinMembersToGroups(members, groups);
 
-        Ticket ticket = createTicket(TicketStatus.STUDY, member, study, group);
-        ticketRepository.save(ticket);
-    }
+        studies = createStudies(3);
+        studyTickets = createStudyTickets(members, groups, studies);
 
-    @Test
-    void findGroupStudies() {
-        //given
-        Member member1 = createMember("member1", "member1");
-        memberRepository.save(member1);
-
-        Group group1 = groupRepository.findAll().get(0);
-        GroupMember groupMember1 = GroupMember.createGroupMember(member1, GroupRole.USER);
-        group1 .addGroupMember(groupMember1);
-
-        Study study1 = createStudy("테스트스터디1");
-        studyRepository.save(study1);
-
-        Ticket ticket1 = getEndTicket(member1, group1 , study1, 2);
-        ticketRepository.save(ticket1);
-
-        //when
-        List<Group> groups = query
-                .select(group)
-                .from(group)
-                .join(group.groupMembers, groupMember).fetchJoin()
-                .join(groupMember.member, member).fetchJoin()
-                .where(categoryEq(null), nameContains(null), studiesIn(null))
-                .limit(10)
-                .offset(0)
-                .fetch();
-
-//        List<Long> groupIds = groups.stream().map(Group::getId).collect(Collectors.toList());
-        List<GroupStudyDto> groupStudies = query
-                .select(Projections.constructor(GroupStudyDto.class,
-                        study.id,
-                        group.id,
-                        study.name,
-                        record.activeTime.sum()
-                ))
-                .from(study)
-                .join(study.tickets, ticket)
-                .join(ticket.record, record)
-                .join(ticket.group, group)
-                .where(group.in(groups))
-                .groupBy(study.id)
-                .limit(10)
-                .fetch();
-
-        //then
-        assertThat(groups).contains(group1);
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        studyRepository.saveAll(studies);
+        ticketRepository.saveAll(studyTickets);
     }
 
     @Test
     void findStudies_조건없음() {
         //given
         List<Member> members = createMembers(20);
-        List<Group> groups = createGroups(members, 2);
+        List<Group> groups = createGroups(members, 3);
         MyUtils.joinMembersToGroups(members, groups);
 
-        List<Study> studies = createStudies(2);
-        List<Ticket> tickets = createTickets(TicketStatus.STUDY, members, groups, studies);
+        List<Study> studies = createStudies(5);
+        List<Ticket> tickets = createStudyTickets(members, groups, studies);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);
@@ -135,47 +97,74 @@ public class StudyRepositoryCustomTest {
 
         //then
         assertThat(result.getContent()).containsAnyElementsOf(studies);
-
     }
 
-    private BooleanExpression studiesIn(List<Study> studies) {
-        return studies != null ? study.in(studies) : null;
+    @Test
+    void findStudies_회원조건() {
+        //given
+        List<Member> members = createMembers(20);
+        List<Group> groups = createGroups(members, 3);
+        MyUtils.joinMembersToGroups(members, groups);
+
+        List<Study> studies = createStudies(5);
+        List<Ticket> tickets = createStudyTickets(members, groups, studies);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        studyRepository.saveAll(studies);
+        ticketRepository.saveAll(tickets);
+
+        //when
+        Long memberId = members.get(0).getId();
+        Long groupId = null;
+        String search = null;
+        LocalDateTime startTime = LocalDateTime.now();
+        int days = 6;
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        Page<Study> result = studyRepository.findStudies(memberId, groupId, search, startTime.minusDays(days), startTime, pageRequest);
+
+        //then
+        List<Ticket> filteredTickets = tickets.stream()
+                .filter(ticket ->
+                        ticket.getMember().getId().equals(memberId)
+                        && ticket instanceof StudyTicket)
+                .collect(Collectors.toList());
+        List<StudyTicket> testStudyTickets = filteredTickets.stream().map(ticket -> (StudyTicket) ticket).collect(Collectors.toList());
+        List<Study> testStudies = testStudyTickets.stream().map(StudyTicket::getStudy).collect(Collectors.toList());
+
+        assertThat(result.getContent()).containsAnyElementsOf(testStudies);
     }
 
-    private BooleanExpression categoryEq(GroupCategory category) {
-        return category != null ? group.category.eq(category) : null;
+    @Test
+    void findStudies_그룹조건() {
+        //given
+        Group testGroup = groups.get(0);
+        LocalDateTime startTime = LocalDateTime.now().minusHours(1);
+        LocalDateTime endTime = startTime.plusHours(2);
+
+        List<Study> testStudiesInGroup = getStudiesInGroup(testGroup);
+
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        Page<Study> studies = studyRepository.findStudies(
+                null, testGroup.getId(), null,
+                startTime, endTime,
+                pageRequest);
+        List<Study> findStudies = studies.getContent();
+
+        //then
+        assertThat(findStudies).containsExactlyInAnyOrderElementsOf(testStudiesInGroup);
     }
 
-    private BooleanExpression nameContains(String search) {
-        return search != null ? group.name.contains(search) : null;
+    private List<Study> getStudiesInGroup(Group testGroup) {
+        List<Ticket> testStudyTickets = testGroup.getTickets().stream().filter(ticket -> {
+            return ticket instanceof StudyTicket;
+        }).collect(Collectors.toList());
+
+        return testStudyTickets.stream().map(ticket -> {
+            StudyTicket studyTicket1 = (StudyTicket) ticket;
+            return studyTicket1.getStudy();
+        }).distinct().collect(Collectors.toList());
     }
 
-    @Data
-    public static class GroupStudyDto {
-        private Long studyId;
-        private Long groupId;
-        private String name;
-        private Long studyTime;
-
-        public GroupStudyDto() {
-        }
-
-        public GroupStudyDto(Long studyId, Long groupId, String name, Long studyTime) {
-            this.studyId = studyId;
-            this.groupId = groupId;
-            this.name = name;
-            this.studyTime = studyTime;
-        }
-    }
-
-    private Ticket getEndTicket(Member member, Group group, Study study, long hours) {
-        Ticket ticket = createTicket(TicketStatus.STUDY, member, study, group);
-        setField(ticket, "endTime", ticket.getStartTime().plusHours(hours));
-        ZoneOffset offset = ZoneOffset.of("+09:00");
-        setField(ticket, "activeTime",
-                ticket.getRecord().getExpiredTime().toEpochSecond(offset)-ticket.getStartTime().toEpochSecond(offset));
-        setField(ticket, "memberStatus", TicketStatus.END);
-
-        return ticket;
-    }
 }

--- a/src/test/java/seong/onlinestudy/repository/StudyRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/StudyRepositoryTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static seong.onlinestudy.MyUtils.*;
-import static seong.onlinestudy.domain.TicketStatus.STUDY;
 
 @DataJpaTest
 class StudyRepositoryTest {
@@ -37,119 +36,5 @@ class StudyRepositoryTest {
     @Autowired
     GroupRepository groupRepository;
 
-    @Test
-    void findStudiesWithMember() {
-        //given
-        List<Member> members = createMembers(10);
-        memberRepository.saveAll(members);
-
-        List<Study> studies = createStudies(6);
-        studyRepository.saveAll(studies);
-
-        Group group = createGroup("group", 30, members.get(0));
-        groupRepository.save(group);
-
-        Ticket ticket = createTicket(STUDY, members.get(0), studies.get(4), group);
-        ticketRepository.save(ticket);
-        setField(ticket, "activeTime", 3600);
-        Ticket ticket1 = createTicket(STUDY, members.get(0), studies.get(5), group);
-        ticketRepository.save(ticket1);
-
-        List<Ticket> tickets = new ArrayList<>();
-        for(int i=1; i<members.size(); i++) {
-            GroupMember.createGroupMember(members.get(i), GroupRole.USER);
-            tickets.add(createTicket(STUDY, members.get(i), studies.get(i%4), group));
-        }
-        ticketRepository.saveAll(tickets);
-
-
-        //when
-        LocalDateTime now = LocalDateTime.now();
-
-        List<Study> findStudies = em.createQuery("select s from Study s" +
-                        " join s.tickets t on t.member = :member and t.startTime >= :startTime and t.startTime < :endTime" +
-                        " join Record r" +
-                        " group by s.id" +
-                        " order by sum(r.activeTime) desc", Study.class)
-                .setParameter("member", members.get(0))
-                .setParameter("startTime", now.minusDays(3))
-                .setParameter("endTime", now.plusDays(3))
-                .getResultList();
-
-/*        Page<Study> studiesByMember
-                = studyRepository.findStudiesByMember(members.get(0), now.minusDays(3), now.plusDays(3), PageRequest.of(0, 2));
-        List<Study> findStudies = studiesByMember.getContent();*/
-
-        //then
-        assertThat(findStudies).containsExactlyElementsOf(List.of(studies.get(4), studies.get(5)));
-    }
-
-    @Test
-    void findStudiesWithMember_티켓페치조인() {
-        //given
-        List<Member> members = createMembers(10);
-        memberRepository.saveAll(members);
-
-        List<Study> studies = createStudies(6);
-        studyRepository.saveAll(studies);
-
-        Group group = createGroup("group", 30, members.get(0));
-        groupRepository.save(group);
-
-        Ticket ticket = createTicket(STUDY, members.get(0), studies.get(4), group);
-        ticketRepository.save(ticket);
-        setTicketEnd(ticket, 3600);
-
-        Ticket ticket1 = createTicket(STUDY, members.get(0), studies.get(5), group);
-        ticketRepository.save(ticket1);
-
-        Ticket ticket2 = createTicket(STUDY, members.get(0), studies.get(4), group);
-        ticketRepository.save(ticket2);
-        setTicketEnd(ticket2, 2800);
-
-        List<Ticket> tickets = new ArrayList<>();
-        for(int i=1; i<members.size(); i++) {
-            GroupMember.createGroupMember(members.get(i), GroupRole.USER);
-            tickets.add(createTicket(STUDY, members.get(i), studies.get(i%4), group));
-        }
-        ticketRepository.saveAll(tickets);
-
-
-        //when
-        LocalDateTime now = LocalDateTime.now();
-
-/*        List<Study> findStudies = em.createQuery("select distinct s from Study s" +
-                        " join fetch s.tickets t " +
-                        " where t.member = :member and t.startTime >= :startTime and t.startTime < :endTime" +
-                        " order by t.startTime desc", Study.class)
-                .setParameter("member", members.get(0))
-                .setParameter("startTime", now.minusDays(3))
-                .setParameter("endTime", now.plusDays(3))
-                .getResultList();*/
-
-        Page<Study> studiesByMember
-                = studyRepository.findStudiesByMember(members.get(0).getId(), now.minusDays(3), now.plusDays(3), PageRequest.of(0, 2));
-        List<Study> findStudies = studiesByMember.getContent();
-
-        //then
-        assertThat(findStudies).containsExactlyElementsOf(List.of(studies.get(4), studies.get(5)));
-        List<StudyDto> studyDtos = findStudies.stream().map(study -> {
-            StudyDto studyDto = StudyDto.from(study);
-            studyDto.setStudyTime(study);
-
-            return studyDto;
-        }).collect(Collectors.toList());
-
-        //티켓이 만료되어 활성화된 시간이 0보다 큰 경우
-        assertThat(studyDtos).anySatisfy(studyDto -> {
-            assertThat(studyDto.getStudyTime()).isEqualTo(3600 + 2800);
-            assertThat(studyDto.getEndTime()).isEqualTo(ticket.getRecord().getExpiredTime().format(DateTimeFormatter.ISO_DATE_TIME));
-        });
-        //티켓이 만료되지 않아 활성화된 시간이 0인 경우
-        assertThat(studyDtos).anySatisfy(studyDto -> {
-            assertThat(studyDto.getStudyTime()).isEqualTo(0);
-            assertThat(studyDto.getEndTime()).isEqualTo(ticket1.getStartTime().format(DateTimeFormatter.ISO_DATE_TIME));
-        });
-    }
 
 }

--- a/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
@@ -52,14 +52,14 @@ public class TicketRepositoryCustomTest {
 
         MyUtils.joinMembersToGroups(members, groups);
 
-        studyTickets = MyUtils.createStudyTickets(members, groups, studies);
+        studyTickets = MyUtils.createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);
         studyRepository.saveAll(studies);
         ticketRepository.saveAll(this.studyTickets);
 
-        restTickets = MyUtils.createRestTickets(members, groups);
+        restTickets = MyUtils.createRestTickets(members, groups, false);
 
         ticketRepository.saveAll(restTickets);
 

--- a/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/TicketRepositoryCustomTest.java
@@ -1,6 +1,5 @@
 package seong.onlinestudy.repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
-import seong.onlinestudy.request.GroupCreateRequest;
-import seong.onlinestudy.request.MemberCreateRequest;
 
 import javax.persistence.EntityManager;
 
@@ -21,10 +18,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static seong.onlinestudy.domain.QGroup.group;
-import static seong.onlinestudy.domain.QMember.member;
-import static seong.onlinestudy.domain.QStudy.study;
-import static seong.onlinestudy.domain.QTicket.ticket;
 
 @DataJpaTest
 public class TicketRepositoryCustomTest {
@@ -46,7 +39,7 @@ public class TicketRepositoryCustomTest {
     List<Member> members = new ArrayList<>();
     List<Group> groups = new ArrayList<>();
     List<Study> studies = new ArrayList<>();
-    List<Ticket> tickets = new ArrayList<>();
+    List<Ticket> studyTickets = new ArrayList<>();
     List<Ticket> restTickets = new ArrayList<>();
 
     @BeforeEach
@@ -57,36 +50,19 @@ public class TicketRepositoryCustomTest {
         groups = MyUtils.createGroups(members, 10);
         studies = MyUtils.createStudies(10);
 
-        for(int i=10; i<50; i++) {
-            GroupMember groupMember = GroupMember.createGroupMember(members.get(i), GroupRole.USER);
-            groups.get(i%10).addGroupMember(groupMember);
-        }
+        MyUtils.joinMembersToGroups(members, groups);
 
-        for (int i=0; i<50; i++) {
-            Ticket ticket = MyUtils.createTicket(TicketStatus.STUDY, members.get(i), studies.get(i % 10), groups.get(i % 10));
-            tickets.add(ticket);
-        }
+        studyTickets = MyUtils.createStudyTickets(members, groups, studies);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);
         studyRepository.saveAll(studies);
-        ticketRepository.saveAll(tickets);
+        ticketRepository.saveAll(this.studyTickets);
 
-        for(int i=0; i<10; i++) {
-            Ticket ticket = MyUtils.createTicket(TicketStatus.REST, members.get(i), studies.get(i % 10), groups.get(i % 10));
-            restTickets.add(ticket);
-        }
+        restTickets = MyUtils.createRestTickets(members, groups);
+
         ticketRepository.saveAll(restTickets);
 
-    }
-
-    @Test
-    void 저장데이터확인() {
-        List<Group> findGroups = groupRepository.findAll();
-        assertThat(findGroups.size()).isEqualTo(10);
-
-        List<Study> findStudies = studyRepository.findAll();
-        assertThat(findStudies.size()).isEqualTo(10);
     }
 
     @Test
@@ -101,9 +77,12 @@ public class TicketRepositoryCustomTest {
                 = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
 
         //then
-        assertThat(findTickets.size()).isEqualTo(tickets.size() + restTickets.size());
+        assertThat(findTickets.size()).isEqualTo(studyTickets.size() + restTickets.size());
         assertThat(findTickets).anySatisfy(findTicket -> {
-            assertThat(findTicket.getStudy()).isNull();
+            if(findTicket instanceof StudyTicket) {
+                StudyTicket studyTicket = (StudyTicket) findTicket;
+                assertThat(studyTicket.getStudy()).isNotNull();
+            }
         });
     }
 
@@ -116,14 +95,22 @@ public class TicketRepositoryCustomTest {
 
         //when
         List<Ticket> findTickets
-                = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
+                = ticketRepository.findTickets(memberId, groupId, studyId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
 
         //then
-        List<Study> findStudies = findTickets.stream().map(Ticket::getStudy).collect(Collectors.toList());
-        assertThat(findStudies).allSatisfy(studyInner -> studyInner.getId().equals(studyId));
+        List<StudyTicket> testStudyTickets = studyTickets.stream()
+                .map(ticket -> (StudyTicket) ticket)
+                .collect(Collectors.toList());
+        List<StudyTicket> testFilteredTickets = testStudyTickets.stream()
+                .filter(studyTicket -> studyTicket.getStudy().equals(studies.get(0)))
+                .collect(Collectors.toList());
 
-        Set<Study> findStudiesRemoveDuplicate = new HashSet<>(findStudies);
-        assertThat(findStudiesRemoveDuplicate.size()).isEqualTo(1);
+        List<StudyTicket> findStudyTickets = findTickets.stream()
+                .map(ticket -> (StudyTicket) ticket)
+                .collect(Collectors.toList());
+
+        assertThat(testFilteredTickets).containsExactlyInAnyOrderElementsOf(findStudyTickets);
+
     }
 
     @Test
@@ -135,7 +122,11 @@ public class TicketRepositoryCustomTest {
 
         //when
         List<Ticket> findTickets
-                = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
+                = ticketRepository.findTickets(
+                        memberId, groupId, studyId,
+                        LocalDateTime.now().minusHours(1),
+                        LocalDateTime.now().plusHours(1)
+        );
 
         //then
         List<Group> findGroups = findTickets.stream().map(Ticket::getGroup).collect(Collectors.toList());
@@ -154,7 +145,11 @@ public class TicketRepositoryCustomTest {
 
         //when
         List<Ticket> findTickets
-                = ticketRepository.findTickets(studyId, groupId, memberId, LocalDateTime.now().minusHours(1), LocalDateTime.now().plusHours(1));
+                = ticketRepository.findTickets(
+                        memberId, groupId, studyId,
+                        LocalDateTime.now().minusHours(1),
+                        LocalDateTime.now().plusHours(1)
+        );
 
         //then
         List<Member> findMembers = findTickets.stream().map(Ticket::getMember).collect(Collectors.toList());

--- a/src/test/java/seong/onlinestudy/repository/TicketRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/TicketRepositoryTest.java
@@ -9,7 +9,6 @@ import seong.onlinestudy.domain.*;
 
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -47,7 +46,7 @@ class TicketRepositoryTest {
         joinMembersToGroups(members, groups);
 
         studies = createStudies(3);
-        studyTickets = createStudyTickets(members, groups, studies);
+        studyTickets = createStudyTickets(members, groups, studies, false);
 
         memberRepository.saveAll(members);
         groupRepository.saveAll(groups);

--- a/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +13,7 @@ import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.domain.Post;
 import seong.onlinestudy.domain.PostCategory;
 import seong.onlinestudy.repository.CommentRepository;
+import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.repository.PostRepository;
 import seong.onlinestudy.request.CommentCreateRequest;
 import seong.onlinestudy.request.CommentUpdateRequest;
@@ -36,8 +38,11 @@ class CommentServiceTest {
     PostRepository postRepository;
     @Mock
     CommentRepository commentRepository;
+    @Mock
+    MemberRepository memberRepository;
 
     @Test
+    @DisplayName("댓글 생성")
     void createComment() {
         //given
         String content = "commentA";
@@ -52,6 +57,7 @@ class CommentServiceTest {
         CommentCreateRequest request = new CommentCreateRequest();
         request.setContent(content);
 
+        given(memberRepository.findById(any())).willReturn(Optional.of(member));
         given(postRepository.findById(any())).willReturn(Optional.of(post));
 
         //when
@@ -63,6 +69,7 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("댓글 업데이트")
     void updateComment() {
         String content = "content";
 
@@ -90,6 +97,7 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("댓글 삭제")
     void deleteComment() {
         //given
         String content = "content";

--- a/src/test/java/seong/onlinestudy/service/StudyServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/StudyServiceTest.java
@@ -1,18 +1,14 @@
 package seong.onlinestudy.service;
 
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MockMvc;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.StudyDto;
@@ -23,12 +19,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static seong.onlinestudy.MyUtils.*;
-import static seong.onlinestudy.domain.TicketStatus.STUDY;
 
 @ExtendWith(MockitoExtension.class)
 class StudyServiceTest {
@@ -40,6 +34,7 @@ class StudyServiceTest {
     StudyRepository studyRepository;
 
     @Test
+    @DisplayName("스터디 목록 조회_검색어 조건")
     void getStudies_검색어있음() {
         Member member = createMember("member", "member");
         setField(member, "id", 1L);
@@ -66,6 +61,7 @@ class StudyServiceTest {
     }
 
     @Test
+    @DisplayName("티켓 목록 조회_조건 없음")
     void getStudies_검색어없음() {
         Member member = createMember("member", "member");
         setField(member, "id", 1L);
@@ -76,7 +72,7 @@ class StudyServiceTest {
         Group group = createGroup("group", 30, member);
 
         for(int i=0; i<3; i++) {
-            Ticket ticket = createTicket(STUDY, member, studies.get(i), group);
+            Ticket ticket = createStudyTicket(member, group, studies.get(i));
             MyUtils.setTicketEnd(ticket, 3600);
         }
 


### PR DESCRIPTION
## 개요
Ticket 엔티티 클래스 정규화 및 그로 인한 코드 변경 반영

## 작업 내용
Ticket 엔티티가 정규형을 만족하지 못하는 문제를 인지하였습니다.
Ticket 엔티티의 ticketStatus 필드에 의해서 연관관계를 맺은 Study 필드가 결정되는 문제가 있었고 이에 따라 ticketStatus 필드를 제거하였습니다.
Ticket은 추상 클래스로 선언하고, 기존의 ticketStatus에 의해 구분되던 Study, Rest(공부, 휴식) 여부를 StudyTicket, RestTicket으로 Ticket 클래스를 상속받는 엔티티 클래스로 분리하였습니다.
다만, StudyTicket과 RestTicket의 차이는 Study 필드 하나뿐이라는 점을 고려하여 Ticket, StudyTicket, RestTicket 테이블로 분리한 구조를 반정규화하여 단일테이블 전략을 이용하는 방향으로 가기로 결정했습니다.
이에 따라 응답 API를 변경하지 않는 선에서 엔티티, DTO, Service, Repository 및 테스트 코드를 수정하였습니다.