### PR TITLE
fix: 스터디 이름 조건으로 스터디 목록 요청시 의도하지 않은 결과가 출력되는 문제 수정

### DIFF
--- a/src/main/java/seong/onlinestudy/repository/querydsl/StudyRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/StudyRepositoryImpl.java
@@ -57,8 +57,8 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom{
                         memberIdEq(studyTicket.member, memberId),
                         groupIdEq(studyTicket.group, groupId),
                         studyNameContains(search),
-                        studyTicket.startTime.goe(startTime),
-                        studyTicket.startTime.lt(endTime)
+                        startTimeGoe(startTime),
+                        endTimeLt(endTime)
                 )
                 .groupBy(study.id)
                 .orderBy(studyTicket.record.activeTime.sum().desc())
@@ -74,13 +74,21 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom{
                         memberIdEq(studyTicket.member, memberId),
                         groupIdEq(studyTicket.group, groupId),
                         studyNameContains(search),
-                        studyTicket.startTime.goe(startTime),
-                        studyTicket.startTime.lt(endTime)
+                        startTimeGoe(startTime),
+                        endTimeLt(endTime)
                 )
                 .fetchOne();
 
 
         return new PageImpl<>(result, pageable, count);
+    }
+
+    private BooleanExpression endTimeLt(LocalDateTime endTime) {
+        return endTime != null ? studyTicket.startTime.lt(endTime) : null;
+    }
+
+    private BooleanExpression startTimeGoe(LocalDateTime startTime) {
+        return startTime != null ? studyTicket.startTime.goe(startTime) : null;
     }
 
     private BooleanExpression studyNameContains(String search) {

--- a/src/main/java/seong/onlinestudy/service/StudyService.java
+++ b/src/main/java/seong/onlinestudy/service/StudyService.java
@@ -38,8 +38,13 @@ public class StudyService {
 
     public Page<StudyDto> getStudies(StudiesGetRequest request, Member loginMember) {
         PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
-        LocalDateTime startTime = request.getDate().atStartOfDay().plusHours(TimeConst.DAY_START);
-        LocalDateTime endTime = startTime.plusDays(request.getDays());
+
+        LocalDateTime startTime = null;
+        LocalDateTime endTime = null;
+        if(request.getDate() != null) {
+            startTime = request.getDate().atStartOfDay().plusHours(TimeConst.DAY_START);
+            endTime = startTime.plusDays(request.getDays());
+        }
 
         Page<Study> findStudies = studyRepository.findStudies(
                 request.getMemberId(),

--- a/src/test/java/seong/onlinestudy/controller/StudyControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/StudyControllerTest.java
@@ -1,0 +1,85 @@
+package seong.onlinestudy.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import seong.onlinestudy.MyUtils;
+import seong.onlinestudy.SessionConst;
+import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.dto.StudyDto;
+import seong.onlinestudy.request.study.StudiesGetRequest;
+import seong.onlinestudy.service.StudyService;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static seong.onlinestudy.SessionConst.LOGIN_MEMBER;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(controllers = StudyController.class)
+class StudyControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @MockBean
+    StudyService studyService;
+
+    MockHttpSession session;
+
+    public StudyControllerTest() {
+        session = new MockHttpSession();
+    }
+
+    @Test
+    void createStudy() {
+    }
+
+    @Test
+    void getStudies() {
+    }
+
+    @Test
+    void getStudies_날짜조건없음() throws Exception {
+        //given
+        Member member = MyUtils.createMember("member", "member123!");
+        session.setAttribute(LOGIN_MEMBER, member);
+
+        StudiesGetRequest request = new StudiesGetRequest();
+        request.setDate(null);
+
+        StudyDto studyDto = new StudyDto();
+        PageImpl<StudyDto> studyDtosWithPage = new PageImpl<>(List.of(studyDto));
+
+        given(studyService.getStudies(any(), any())).willReturn(studyDtosWithPage);
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/v1/studies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .session(session));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/StudyRepositoryCustomTest.java
@@ -148,6 +148,23 @@ public class StudyRepositoryCustomTest {
     }
 
     @Test
+    void findStudies_검색어조건() {
+        //given
+        Study testStudy = createStudy("뷰");
+        studyRepository.save(testStudy);
+
+        //when
+        LocalDateTime startTime = null;
+        LocalDateTime endTime = null;
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        Page<Study> findStudiesWithPage = studyRepository.findStudies(null, null, "뷰", startTime, endTime, pageRequest);
+
+        //then
+        List<Study> findStudies = findStudiesWithPage.getContent();
+        assertThat(findStudies).contains(testStudy);
+    }
+
+    @Test
     void findStudiesInGroups() {
         //given
         Group testGroup = groups.get(0);


### PR DESCRIPTION
## 개요
스터디 이름 조건으로 스터디 목록 요청시 검색되지 않는 문제를 수정하였습니다.

## 작업 내용
study를 생성만하고, 해당 study로 ticket을 발급받지 않은 경우에 해당 문제가 발생. 
QueryDSL을 위한 studyRepositoryImpl 의 findStudies메서드에서 사용하는 studyTicket.startTime.goe(시작시간) 등의 조건으로 인해 study 티켓이 검색되지 않았습니다. 따라서 '시작시간'이 null 인 경우 해당 조건을 제외할 수 있도록 수정하였습니다.

ticketRepositoryImpl 에서 사용되는 메서드에도 유사한 조건으로 검색이 이루어지나 ticket을 대상으로 쿼리를 날려 별문제가 없었던 반면, 문제가 발생한 메서드에서는 study를 대상으로 쿼리를 날리고, studyTicket을 외부 조인해서 사용하면서 ticket 데이터가 없는 study들은 검색 조건에서 걸러졌기 때문에 이와 같은 문제가 발생했습니다.
