### PR TITLE
게시글, 댓글 soft-delete 및 댓글 목록 요청 추가

### DIFF
--- a/src/main/java/seong/onlinestudy/controller/CommentController.java
+++ b/src/main/java/seong/onlinestudy/controller/CommentController.java
@@ -1,15 +1,21 @@
 package seong.onlinestudy.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
+import seong.onlinestudy.controller.response.PageResult;
 import seong.onlinestudy.controller.response.Result;
 import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.dto.CommentDto;
 import seong.onlinestudy.exception.InvalidSessionException;
+import seong.onlinestudy.request.CommentsGetRequest;
 import seong.onlinestudy.request.comment.CommentCreateRequest;
 import seong.onlinestudy.request.comment.CommentUpdateRequest;
 import seong.onlinestudy.service.CommentService;
 
 import javax.validation.Valid;
+
+import java.util.List;
 
 import static seong.onlinestudy.SessionConst.LOGIN_MEMBER;
 
@@ -32,7 +38,14 @@ public class CommentController {
         return new Result<>("201", commentId);
     }
 
-    @PostMapping("/comment/{commentId}")
+    @GetMapping("/comments")
+    public Result<List<CommentDto>> getComments(@Valid CommentsGetRequest request) {
+        Page<CommentDto> commentsWithPage = commentService.getComments(request);
+
+        return new PageResult<>("200", commentsWithPage.getContent(), commentsWithPage);
+    }
+
+    @PatchMapping("/comment/{commentId}")
     public Result<Long> updateComment(@PathVariable("commentId") Long commentId, CommentUpdateRequest request,
                                       @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
         if (loginMember == null) {
@@ -44,7 +57,7 @@ public class CommentController {
         return new Result<>("200", updateCommentId);
     }
 
-    @PatchMapping("/comment/{commentId}")
+    @DeleteMapping("/comment/{commentId}")
     public Result<Long> deleteComment(@PathVariable("commentId") Long commentId,
                                         @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
         if (loginMember == null) {

--- a/src/main/java/seong/onlinestudy/controller/CommentController.java
+++ b/src/main/java/seong/onlinestudy/controller/CommentController.java
@@ -46,7 +46,7 @@ public class CommentController {
     }
 
     @PatchMapping("/comment/{commentId}")
-    public Result<Long> updateComment(@PathVariable("commentId") Long commentId, CommentUpdateRequest request,
+    public Result<Long> updateComment(@PathVariable("commentId") Long commentId, @RequestBody @Valid CommentUpdateRequest request,
                                       @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
         if (loginMember == null) {
             throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");

--- a/src/main/java/seong/onlinestudy/controller/PostController.java
+++ b/src/main/java/seong/onlinestudy/controller/PostController.java
@@ -50,7 +50,7 @@ public class PostController {
         return new Result<>("200", post);
     }
 
-    @PostMapping("/post/{postId}")
+    @PatchMapping("/post/{postId}")
     public Result<Long> updatePost(@PathVariable("postId") Long postId,
                                    @RequestBody @Valid PostUpdateRequest request,
                                    @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
@@ -62,7 +62,7 @@ public class PostController {
         return new Result<>("200", updatePostId);
     }
 
-    @PatchMapping("/post/{postId}")
+    @DeleteMapping("/post/{postId}")
     public Result<String> deletePost(@PathVariable("postId") Long postId,
                                    @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
         if(loginMember == null) {

--- a/src/main/java/seong/onlinestudy/domain/Comment.java
+++ b/src/main/java/seong/onlinestudy/domain/Comment.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.domain;
 
 import lombok.Getter;
+import org.hibernate.annotations.Where;
 import seong.onlinestudy.request.comment.CommentCreateRequest;
 import seong.onlinestudy.request.comment.CommentUpdateRequest;
 
@@ -8,6 +9,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
+@Where(clause = "deleted=false")
 @Getter
 public class Comment {
 
@@ -18,7 +20,7 @@ public class Comment {
 
     @Lob
     private String content;
-    private Boolean isDeleted;
+    private Boolean deleted;
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,16 +44,16 @@ public class Comment {
     }
 
     public void delete() {
-        this.isDeleted = true;
+        this.deleted = true;
 
-        this.post.getComments().remove(this);
-        this.post = null;
+//        this.post.getComments().remove(this);
+//        this.post = null;
     }
 
     public static Comment create(CommentCreateRequest request) {
         Comment comment = new Comment();
         comment.content = request.getContent();
-        comment.isDeleted = false;
+        comment.deleted = false;
         comment.createdAt = LocalDateTime.now();
 
         return comment;

--- a/src/main/java/seong/onlinestudy/domain/Post.java
+++ b/src/main/java/seong/onlinestudy/domain/Post.java
@@ -56,13 +56,10 @@ public class Post {
         this.viewCount++;
     }
 
-    /**
-     * 제목, 본문 업데이트
-     * @param request title(제목), content(본문)
-     */
     public void update(PostUpdateRequest request) {
         this.title = request.getTitle();
         this.content = request.getContent();
+        this.category = request.getCategory();
     }
 
     public void delete() {

--- a/src/main/java/seong/onlinestudy/domain/Post.java
+++ b/src/main/java/seong/onlinestudy/domain/Post.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.domain;
 
 import lombok.Getter;
+import org.hibernate.annotations.Where;
 import seong.onlinestudy.request.post.PostCreateRequest;
 import seong.onlinestudy.request.post.PostUpdateRequest;
 
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Where(clause = "deleted=false")
 @Getter
 public class Post {
 
@@ -26,7 +28,7 @@ public class Post {
     private PostCategory category;
     private int viewCount;
     private LocalDateTime createdAt;
-    private Boolean isDeleted;
+    private Boolean deleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -36,7 +38,7 @@ public class Post {
     @JoinColumn(name = "group_id")
     private Group group;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
     List<PostStudy> postStudies = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
@@ -63,13 +65,8 @@ public class Post {
         this.content = request.getContent();
     }
 
-    /**
-     * 게시글 삭제 상태로 변경,
-     * postStudies 리스트 clear
-     */
     public void delete() {
-        this.isDeleted = true;
-        this.postStudies.clear();
+        this.deleted = true;
     }
 
     public static Post createPost(PostCreateRequest request, Member member) {
@@ -79,7 +76,7 @@ public class Post {
         post.category = request.getCategory();
         post.viewCount = 0;
         post.createdAt = LocalDateTime.now();
-        post.isDeleted = false;
+        post.deleted = false;
 
         post.member = member;
         member.getPosts().add(post);

--- a/src/main/java/seong/onlinestudy/repository/CommentRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package seong.onlinestudy.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import seong.onlinestudy.domain.Comment;
+import seong.onlinestudy.repository.querydsl.CommentRepositoryCustom;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 }

--- a/src/main/java/seong/onlinestudy/repository/PostStudyRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/PostStudyRepository.java
@@ -27,4 +27,6 @@ public interface PostStudyRepository extends JpaRepository<PostStudy, Long> {
     @Query("select ps from PostStudy ps join fetch ps.study s join fetch ps.post p" +
             " where p in :posts")
     List<PostStudy> findStudiesWhereInPosts(@Param("posts") List<Post> posts);
+
+    void deleteAllByPost(Post post);
 }

--- a/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package seong.onlinestudy.repository.querydsl;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import seong.onlinestudy.domain.Comment;
+
+public interface CommentRepositoryCustom {
+
+    Page<Comment> findComments(Long memberId, Long postId, Pageable pageable);
+}

--- a/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryImpl.java
@@ -1,0 +1,58 @@
+package seong.onlinestudy.repository.querydsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import seong.onlinestudy.domain.Comment;
+import seong.onlinestudy.domain.QMember;
+import seong.onlinestudy.domain.QPost;
+
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static seong.onlinestudy.domain.QComment.comment;
+import static seong.onlinestudy.domain.QMember.member;
+import static seong.onlinestudy.domain.QPost.post;
+
+public class CommentRepositoryImpl implements CommentRepositoryCustom{
+
+    private JPAQueryFactory query;
+
+    public CommentRepositoryImpl(EntityManager em) {
+        query = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Comment> findComments(Long memberId, Long postId, Pageable pageable) {
+        List<Comment> result = query
+                .select(comment)
+                .from(comment)
+                .join(comment.member, member).fetchJoin()
+                .join(comment.post, post).fetchJoin()
+                .where(memberIdEq(member, memberId), postIdEq(post, postId))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        Long count = query
+                .select(comment.id.count())
+                .from(comment)
+                .where(memberIdEq(comment.member, memberId), postIdEq(comment.post, postId))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, count);
+    }
+
+    private BooleanExpression postIdEq(QPost post, Long postId) {
+        return postId != null ? post.id.eq(postId) : null;
+    }
+
+    private BooleanExpression memberIdEq(QMember member, Long memberId) {
+        return memberId != null ? member.id.eq(memberId) : null;
+    }
+}

--- a/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryCustom.java
@@ -16,9 +16,8 @@ public interface PostRepositoryCustom {
      * @param search like '%search%' 조건을 위한 문자열
      * @param category category 검색을 위한 PostCategory enum
      * @param studyIds Study 와 연관관계 조건을 위한 id List
-     * @param deleted 삭제된 게시글 검색 조건
      * @return Comment, Member 와 페치 조인한 Post 목록을 반환
      * */
-    Page<Post> findPostsWithComments(Pageable pageable, Long groupId, String search, PostCategory category, List<Long> studyIds, Boolean deleted);
+    Page<Post> findPostsWithComments(Pageable pageable, Long groupId, String search, PostCategory category, List<Long> studyIds);
 
 }

--- a/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
@@ -25,7 +25,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Page<Post> findPostsWithComments(Pageable pageable, Long groupId, String search, PostCategory category, List<Long> studyIds, Boolean deleted) {
+    public Page<Post> findPostsWithComments(Pageable pageable, Long groupId, String search, PostCategory category, List<Long> studyIds) {
 
         OrderSpecifier order = post.createdAt.desc();
 
@@ -35,7 +35,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .leftJoin(post.comments, comment).fetchJoin()
                 .leftJoin(post.member, member).fetchJoin()
                 .leftJoin(post.postStudies, postStudy)
-                .where(groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds), isDeletedEq(deleted))
+                .where(groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds))
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .orderBy(order)
@@ -45,15 +45,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .select(post.count())
                 .from(post)
                 .leftJoin(post.postStudies, postStudy)
-                .where(groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds), isDeletedEq(deleted))
+                .where(groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds))
                 .fetchOne();
 
 
         return new PageImpl<>(posts, pageable, count);
-    }
-
-    private BooleanExpression isDeletedEq(boolean isDelete) {
-        return post.isDeleted.eq(isDelete);
     }
 
     private BooleanExpression studyIdIn(List<Long> studyIds) {

--- a/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
@@ -53,7 +53,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     private BooleanExpression studyIdIn(List<Long> studyIds) {
-        return studyIds != null ? postStudy.study.id.in(studyIds) : null;
+        return studyIds != null && !studyIds.isEmpty() ? postStudy.study.id.in(studyIds) : null;
     }
 
     private BooleanExpression categoryEq(PostCategory category) {
@@ -61,7 +61,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     private BooleanExpression searchContains(String search) {
-        return search != null ? post.title.contains(search) : null;
+        return search != null && !search.isBlank() ? post.title.contains(search) : null;
     }
 
     private BooleanExpression groupIdEq(Long groupId) {

--- a/src/main/java/seong/onlinestudy/request/CommentsGetRequest.java
+++ b/src/main/java/seong/onlinestudy/request/CommentsGetRequest.java
@@ -1,0 +1,18 @@
+package seong.onlinestudy.request;
+
+import lombok.Data;
+
+@Data
+public class CommentsGetRequest {
+
+    private Long memberId;
+    private Long postId;
+
+    private int page;
+    private int size;
+
+    public CommentsGetRequest() {
+        page = 0;
+        size = 30;
+    }
+}

--- a/src/main/java/seong/onlinestudy/request/post/PostUpdateRequest.java
+++ b/src/main/java/seong/onlinestudy/request/post/PostUpdateRequest.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.request.post;
 
 import lombok.Data;
+import seong.onlinestudy.domain.PostCategory;
 
 import java.util.List;
 
@@ -9,5 +10,6 @@ public class PostUpdateRequest {
 
     private String title;
     private String content;
+    private PostCategory category;
     private List<Long> studyIds;
 }

--- a/src/main/java/seong/onlinestudy/service/CommentService.java
+++ b/src/main/java/seong/onlinestudy/service/CommentService.java
@@ -2,15 +2,19 @@ package seong.onlinestudy.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import seong.onlinestudy.domain.Comment;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.domain.Post;
+import seong.onlinestudy.dto.CommentDto;
 import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.repository.CommentRepository;
 import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.repository.PostRepository;
+import seong.onlinestudy.request.CommentsGetRequest;
 import seong.onlinestudy.request.comment.CommentCreateRequest;
 import seong.onlinestudy.request.comment.CommentUpdateRequest;
 
@@ -73,5 +77,13 @@ public class CommentService {
         comment.delete();
 
         return comment.getId();
+    }
+
+    public Page<CommentDto> getComments(CommentsGetRequest request) {
+        PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
+        Page<Comment> commentsWithPage =
+                commentRepository.findComments(request.getMemberId(), request.getPostId(), pageRequest);
+
+        return commentsWithPage.map(CommentDto::from);
     }
 }

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -80,6 +80,7 @@ public class PostService {
         return savedPost.getId();
     }
 
+    @Transactional
     public PostDto getPost(Long postId) {
         Post post = postRepository.findByIdWithMemberAndGroup(postId)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 게시글입니다."));

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -33,7 +33,7 @@ public class PostService {
         Page<Post> postsWithComments
                 = postRepository.findPostsWithComments(pageRequest,
                 request.getGroupId(), request.getSearch(), request.getCategory(),
-                request.getStudyIds(), request.isDeleted());
+                request.getStudyIds());
 
         List<PostStudy> postStudies = postStudyRepository.findStudiesWhereInPosts(postsWithComments.getContent());
 
@@ -136,6 +136,7 @@ public class PostService {
             throw new PermissionControlException("해당 게시글의 삭제 권한이 없습니다.");
         }
 
+        postStudyRepository.deleteAllByPost(post);
         post.delete();
     }
 }

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -189,7 +189,7 @@ public class MyUtils {
         return comment;
     }
 
-    public static List<Comment> createComments(List<Member> members, List<Post> posts, boolean setId, int endId) {
+    public static List<Comment> createComments(List<Member> members, List<Post> posts, int endId, boolean setId) {
         List<Comment> comments = new ArrayList<>();
         for(int i=0; i<endId; i++) {
             Comment comment = createComment("테스트댓글" + i);

--- a/src/test/java/seong/onlinestudy/api/CommentApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/CommentApiTest.java
@@ -1,0 +1,92 @@
+package seong.onlinestudy.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import seong.onlinestudy.domain.Comment;
+import seong.onlinestudy.domain.Group;
+import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.domain.Post;
+import seong.onlinestudy.repository.CommentRepository;
+import seong.onlinestudy.repository.GroupRepository;
+import seong.onlinestudy.repository.MemberRepository;
+import seong.onlinestudy.repository.PostRepository;
+import seong.onlinestudy.request.CommentsGetRequest;
+
+import java.util.List;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static seong.onlinestudy.MyUtils.*;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class CommentApiTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    GroupRepository groupRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    CommentRepository commentRepository;
+
+    List<Member> members;
+    List<Group> groups;
+    List<Post> posts;
+    List<Comment> comments;
+
+    @BeforeEach
+    void init() {
+        members = createMembers(3);
+        groups = createGroups(members, 2);
+
+        joinMembersToGroups(members, groups);
+
+        posts = createPosts(members, groups, 3, false);
+        comments = createComments(members, posts, 10, false);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        postRepository.saveAll(posts);
+        commentRepository.saveAll(comments);
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회")
+    void getComments() throws Exception {
+        //given
+        Member testMember = members.get(0);
+
+        CommentsGetRequest request = new CommentsGetRequest();
+        request.setMemberId(testMember.getId());
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/v1/comments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/seong/onlinestudy/api/PostApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/PostApiTest.java
@@ -1,0 +1,98 @@
+package seong.onlinestudy.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import seong.onlinestudy.domain.*;
+import seong.onlinestudy.repository.*;
+import seong.onlinestudy.request.post.PostsGetRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static seong.onlinestudy.MyUtils.*;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class PostApiTest {
+
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    ObjectMapper mapper;
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    GroupRepository groupRepository;
+    @Autowired
+    StudyRepository studyRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    CommentRepository commentRepository;
+
+    MockHttpSession session;
+
+    List<Member> members;
+    List<Group> groups;
+    List<Post> posts;
+    List<Comment> comments;
+
+    public PostApiTest() {
+        session = new MockHttpSession();
+    }
+
+    @BeforeEach
+    void init() {
+        members = createMembers(3);
+        groups = createGroups(members, 2);
+
+        joinMembersToGroups(members, groups);
+
+        posts = createPosts(members, groups, 3, false);
+        comments = createComments(members, posts, 10, false);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        postRepository.saveAll(posts);
+        commentRepository.saveAll(comments);
+    }
+
+    @Test
+    void getPosts_검색어조건() throws Exception {
+        //given
+        MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+        request.add("search", "검색");
+
+        Member testMember = members.get(0);
+        Post testPost1 = createPost("검색", "검색테스트", PostCategory.CHAT, testMember);
+        Post testPost2 = createPost("검색검검색", "검색테스트", PostCategory.CHAT, testMember);
+        Post testPost3 = createPost("테스트", "검색테스트", PostCategory.CHAT, testMember);
+
+        postRepository.saveAll(List.of(testPost1, testPost2, testPost3));
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/v1/posts")
+                .params(request));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
@@ -7,9 +7,6 @@ import seong.onlinestudy.domain.Comment;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.domain.Post;
 import seong.onlinestudy.domain.PostCategory;
-import seong.onlinestudy.repository.CommentRepository;
-import seong.onlinestudy.repository.MemberRepository;
-import seong.onlinestudy.repository.PostRepository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
@@ -40,7 +37,7 @@ class CommentRepositoryTest {
         Comment comment = createComment("content");
         comment.setMemberAndPost(member, post);
 
-        List<Comment> comments = createComments(List.of(member), List.of(post), false, 10);
+        List<Comment> comments = createComments(List.of(member), List.of(post), 10, false);
         em.flush();
 
         //when

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
@@ -103,6 +103,34 @@ public class PostRepositoryCustomTest {
     }
 
     @Test
+    @DisplayName("findPosts_검색어 조건")
+    void findPosts_검색어조건() {
+        //given
+        Member testMember = members.get(0);
+        Group testGroup = groups.get(0);
+        Post testPost = createPost("검색", "검색테스트", PostCategory.CHAT, testMember);
+        Post testPost2 = createPost("검검색검", "검색테스트", PostCategory.INFO, testMember);
+        Post testPostNotContain = createPost("테스트", "검색테스트", PostCategory.INFO, testMember);
+        testPost.setGroup(testGroup);
+        testPost2.setGroup(testGroup);
+        testPostNotContain.setGroup(testGroup);
+
+        postRepository.saveAll(List.of(testPost, testPost2, testPostNotContain));
+
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        Page<Post> findPostsWithPage = postRepository.findPostsWithComments(pageRequest, null, "검색", null, null);
+
+        //then
+        List<Post> findPosts = findPostsWithPage.getContent();
+        assertThat(findPosts.size()).isGreaterThan(0);
+
+        assertThat(findPosts).allSatisfy(findPost -> {
+            assertThat(findPost.getTitle()).contains("검색");
+        });
+    }
+
+    @Test
     @DisplayName("findPosts_게시글, 댓글 삭제 대이터 혼합")
     void findPosts_삭제데이터혼합() {
         //given

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
@@ -3,14 +3,18 @@ package seong.onlinestudy.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import seong.onlinestudy.domain.*;
 
 import javax.persistence.EntityManager;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static seong.onlinestudy.MyUtils.*;
@@ -34,24 +38,29 @@ public class PostRepositoryCustomTest {
     @Autowired
     StudyRepository studyRepository;
 
+    List<Member> members;
+    List<Group> groups;
+    List<Post> posts;
+    List<Study> studies;
+
     @BeforeEach
     void init() {
         query = new JPAQueryFactory(em);
 
-        List<Member> members = createMembers(50, false);
+        members = createMembers(20, false);
         memberRepository.saveAll(members);
 
-        List<Group> groups = createGroups(members, 10, false);
+        groups = createGroups(members, 2, false);
         groupRepository.saveAll(groups);
 
-        List<Post> posts = createPosts(members, groups, 10, false);
+        posts = createPosts(members, groups, 3, false);
         postRepository.saveAll(posts);
 
-        List<Study> studies = createStudies(20, false);
+        studies = createStudies(5, false);
         studyRepository.saveAll(studies);
 
-        for(int i=0; i<20; i++) {
-            PostStudy.create(posts.get(i%10), studies.get(i));
+        for(int i=0; i<studies.size(); i++) {
+            PostStudy.create(posts.get(i%posts.size()), studies.get(i));
         }
     }
 
@@ -91,6 +100,37 @@ public class PostRepositoryCustomTest {
 
         //then
         assertThat(posts).containsAll(postList);
+    }
+
+    @Test
+    @DisplayName("findPosts_게시글, 댓글 삭제 대이터 혼합")
+    void findPosts_삭제데이터혼합() {
+        //given
+        Member testMember = members.get(0);
+        Post testPost = posts.get(0);
+        List<Comment> testComments = createComments(List.of(testMember), posts, 10, false);
+
+        //when
+        testPost.delete();
+        for (Comment testComment : testComments) {
+            testComment.delete();
+        }
+        em.flush();
+        em.clear();
+
+        PageRequest pageRequest = PageRequest.of(0, 30);
+        Page<Post> findPostsWithPage
+                = postRepository.findPostsWithComments(pageRequest, null, null, null, null);
+
+        //then
+        List<Post> findPosts = findPostsWithPage.getContent();
+        List<Long> findPostIds = findPosts.stream().map(Post::getId).collect(Collectors.toList());
+        Long testPostId = testPost.getId();
+
+        assertThat(findPostIds).doesNotContain(testPostId);
+        assertThat(findPosts).allSatisfy(findPost -> {
+            assertThat(findPost.getComments().size()).isEqualTo(0);
+        });
     }
 
     private BooleanExpression studyIdIn(List<Long> studyIds) {

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
@@ -1,6 +1,8 @@
 package seong.onlinestudy.repository;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static seong.onlinestudy.MyUtils.*;
 
+@Slf4j
 @DataJpaTest
 public class PostRepositoryTest {
 
@@ -28,6 +31,8 @@ public class PostRepositoryTest {
     GroupRepository groupRepository;
     @Autowired
     StudyRepository studyRepository;
+    @Autowired
+    PostStudyRepository postStudyRepository;
 
     List<Member> members;
     List<Group> groups;
@@ -131,5 +136,23 @@ public class PostRepositoryTest {
         assertThat(findPost).isEqualTo(post);
         List<Study> findStudies = findPost.getPostStudies().stream().map(PostStudy::getStudy).collect(Collectors.toList());
         assertThat(findStudies).containsExactlyInAnyOrderElementsOf(studies);
+    }
+
+    @Test
+    void deletePost() {
+        //given
+        Post testPost = posts.get(0);
+
+        //when
+        testPost.delete();
+        em.flush();
+        em.clear();
+
+        //then
+        List<Post> findPosts = postRepository.findAll();
+        List<Long> findPostIds = findPosts.stream().map(Post::getId).collect(Collectors.toList());
+        Long testPostId = testPost.getId();
+
+        assertThat(findPostIds).doesNotContain(testPostId);
     }
 }

--- a/src/test/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustomTest.java
@@ -1,0 +1,99 @@
+package seong.onlinestudy.repository.querydsl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import seong.onlinestudy.domain.Comment;
+import seong.onlinestudy.domain.Group;
+import seong.onlinestudy.domain.Member;
+import seong.onlinestudy.domain.Post;
+import seong.onlinestudy.repository.CommentRepository;
+import seong.onlinestudy.repository.GroupRepository;
+import seong.onlinestudy.repository.MemberRepository;
+import seong.onlinestudy.repository.PostRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static seong.onlinestudy.MyUtils.*;
+
+@DataJpaTest
+class CommentRepositoryCustomTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    GroupRepository groupRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    CommentRepository commentRepository;
+
+    List<Member> members;
+    List<Group> groups;
+    List<Post> posts;
+    List<Comment> comments;
+
+    @BeforeEach
+    void init() {
+        members = createMembers(3);
+        groups = createGroups(members,2);
+
+        joinMembersToGroups(members, groups);
+
+        posts = createPosts(members, groups, 3, false);
+        comments = createComments(members, posts, 10, false);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        postRepository.saveAll(posts);
+        commentRepository.saveAll(comments);
+    }
+
+    @Test
+    void findComments_회원조건() {
+        //given
+        Member testMember = createMember("member", "member");
+        memberRepository.save(testMember);
+
+        Post testPost = posts.get(0);
+        List<Comment> testComments = createComments(List.of(testMember), List.of(testPost), 5, false);
+
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 30);
+        Page<Comment> findCommentsWithPage = commentRepository.findComments(testMember.getId(), null, pageRequest);
+
+        //then
+        List<Comment> findComments = findCommentsWithPage.getContent();
+
+        assertThat(findComments.size()).isGreaterThan(0);
+        assertThat(findComments).containsExactlyInAnyOrderElementsOf(testComments);
+    }
+
+    @Test
+    void findComments_게시글조건() {
+        //given
+        Member testMember = createMember("member", "member");
+        memberRepository.save(testMember);
+
+        Post testPost = posts.get(0);
+        List<Comment> testMemberComments = createComments(List.of(testMember), List.of(testPost), 5, false);
+
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 30);
+        Page<Comment> findCommentsWithPage = commentRepository.findComments(null, testPost.getId(), pageRequest);
+
+        //then
+        List<Comment> findComments = findCommentsWithPage.getContent();
+        List<Comment> testComments = testPost.getComments();
+
+        assertThat(findComments.size()).isGreaterThan(0);
+        assertThat(findComments).containsExactlyInAnyOrderElementsOf(testComments);
+        assertThat(findComments).containsAnyElementsOf(testMemberComments);
+    }
+
+
+}

--- a/src/test/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/querydsl/CommentRepositoryCustomTest.java
@@ -15,6 +15,7 @@ import seong.onlinestudy.repository.GroupRepository;
 import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.repository.PostRepository;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,6 +23,9 @@ import static seong.onlinestudy.MyUtils.*;
 
 @DataJpaTest
 class CommentRepositoryCustomTest {
+
+    @Autowired
+    EntityManager em;
 
     @Autowired
     MemberRepository memberRepository;
@@ -93,6 +97,26 @@ class CommentRepositoryCustomTest {
         assertThat(findComments.size()).isGreaterThan(0);
         assertThat(findComments).containsExactlyInAnyOrderElementsOf(testComments);
         assertThat(findComments).containsAnyElementsOf(testMemberComments);
+    }
+
+    @Test
+    void findComments_삭제데이터혼합() {
+        //given
+        Member testMember = members.get(0);
+        Post testPost = posts.get(0);
+        List<Comment> testComments = createComments(List.of(testMember), List.of(testPost), 5, false);
+
+        assertThat(testPost.getComments()).containsAll(testComments);
+
+        //when
+        for (Comment testComment : testComments) {
+            testComment.delete();
+        }
+        em.clear();
+
+        //then
+        Post newTestPost = postRepository.findById(testPost.getId()).get();
+        assertThat(newTestPost.getComments()).doesNotContainAnyElementsOf(testComments);
     }
 
 

--- a/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
@@ -108,7 +108,7 @@ class CommentServiceTest {
         Post post = createPost("postA", "postA", PostCategory.CHAT, member);
         setField(post, "id", 1L);
 
-        List<Comment> comments = MyUtils.createComments(List.of(member), List.of(post), true, 10);
+        List<Comment> comments = MyUtils.createComments(List.of(member), List.of(post), 10, true);
 
         Comment comment = MyUtils.createComment(content);
         comment.setMemberAndPost(member, post);

--- a/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/CommentServiceTest.java
@@ -121,8 +121,7 @@ class CommentServiceTest {
         Long commentId = commentService.deleteComment(comment.getId(), member);
 
         //then
-        assertThat(post.getComments()).containsExactlyInAnyOrderElementsOf(comments);
-        assertThat(post.getComments()).doesNotContain(comment);
+        assertThat(comment.getDeleted()).isTrue();
 
     }
 }

--- a/src/test/java/seong/onlinestudy/service/PostServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/PostServiceTest.java
@@ -137,7 +137,7 @@ class PostServiceTest {
 
 
         List<Post> subList = posts.subList(0, 10);
-        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any(), any()))
+        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any()))
                 .willReturn(new PageImpl<>(subList, PageRequest.of(page, size), posts.size()));
 
         //when
@@ -172,7 +172,7 @@ class PostServiceTest {
 
         PostsGetRequest request = new PostsGetRequest();
 
-        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any(), any()))
+        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any()))
                 .willReturn(new PageImpl<>(posts, PageRequest.of(page, size), posts.size()));
         given(postStudyRepository.findStudiesWhereInPosts(anyList()))
                 .willReturn(postStudies);


### PR DESCRIPTION
## 개요
post, comment의 soft-delete 구현. 댓글 목록 요청 api 추가. 몇가지 메서드의 수정

## 작업 내용
post, comment의 soft-delete를 위해 각 클래스에 @Where 애노테이션을 추가하였습니다.
댓글 목록 요청을 위한 api를 작성하였습니다.
그 외에 의도한 결과를 반환하지 않는 부분들에 대해여 애노테이션을 추가하거나 조건을 수정하여 정상적이 결과를 반환하도록 수정하였습니다.