### PR TITLE
회원 업데이트, 삭제 요청 추가

### DIFF
--- a/src/main/java/seong/onlinestudy/controller/MemberController.java
+++ b/src/main/java/seong/onlinestudy/controller/MemberController.java
@@ -68,5 +68,19 @@ public class MemberController {
 
         return new Result<>("200", updatedMemberId);
     }
+
+    @DeleteMapping("/member/{memberId}")
+    public Result<Long> deleteMember(@PathVariable Long memberId,
+                                     @SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember) {
+        if (loginMember == null) {
+            throw new InvalidSessionException("세션이 유효하지 않습니다.");
+        }
+        if(!memberId.equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
+        }
+
+        memberService.deleteMember(memberId);
+
+        return new Result<>("200", memberId);
     }
 }

--- a/src/main/java/seong/onlinestudy/controller/MemberController.java
+++ b/src/main/java/seong/onlinestudy/controller/MemberController.java
@@ -7,8 +7,10 @@ import seong.onlinestudy.controller.response.Result;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.dto.MemberDto;
 import seong.onlinestudy.exception.InvalidSessionException;
+import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.request.member.MemberCreateRequest;
 import seong.onlinestudy.request.member.MemberDuplicateCheckRequest;
+import seong.onlinestudy.request.member.MemberUpdateRequest;
 import seong.onlinestudy.service.MemberService;
 
 import javax.validation.Valid;
@@ -30,21 +32,41 @@ public class MemberController {
         return new Result<>("201", memberId);
     }
 
-    @GetMapping("/member")
-    public Result<MemberDto> getMember(@SessionAttribute(value = LOGIN_MEMBER, required = false)Member loginMember) {
-        if(loginMember == null) {
-            throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");
+    @GetMapping("/member/{memberId}")
+    public Result<MemberDto> getMember(@PathVariable Long memberId,
+                                       @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
+        if (loginMember == null) {
+            throw new InvalidSessionException("세션이 유효하지 않습니다.");
+        }
+        if(!memberId.equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
         }
 
-        MemberDto member = memberService.getMember(loginMember);
+        MemberDto member = memberService.getMember(memberId);
 
         return new Result<>("200", member);
     }
 
     @PostMapping("/members/duplicate")
-    public Result<String> duplicateCheck(@RequestBody @Valid MemberDuplicateCheckRequest request) {
+    public Result<Boolean> duplicateCheck(@RequestBody @Valid MemberDuplicateCheckRequest request) {
         memberService.duplicateCheck(request);
 
-        return new Result<>("200", "ok");
+        return new Result<>("200", false);
+    }
+
+    @PatchMapping("/member/{memberId}")
+    public Result<Long> updateMember(@PathVariable Long memberId, @RequestBody @Valid MemberUpdateRequest request,
+                                     @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
+        if (loginMember == null) {
+            throw new InvalidSessionException("세션이 유효하지 않습니다.");
+        }
+        if(!memberId.equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
+        }
+
+        Long updatedMemberId = memberService.updateMember(memberId, request);
+
+        return new Result<>("200", updatedMemberId);
+    }
     }
 }

--- a/src/main/java/seong/onlinestudy/domain/Member.java
+++ b/src/main/java/seong/onlinestudy/domain/Member.java
@@ -33,6 +33,15 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<Ticket> tickets = new ArrayList<>();
 
+    public void update(MemberUpdateRequest request) {
+        if (StringUtils.hasText(request.getNickname())) {
+            this.nickname = request.getNickname();
+        }
+        if (StringUtils.hasText(request.getPassword())) {
+            this.password = request.getPassword();
+        }
+    }
+
     public static Member createMember(MemberCreateRequest request) {
         Member member = new Member();
         member.username = request.getUsername();

--- a/src/main/java/seong/onlinestudy/domain/Member.java
+++ b/src/main/java/seong/onlinestudy/domain/Member.java
@@ -1,7 +1,10 @@
 package seong.onlinestudy.domain;
 
 import lombok.Getter;
+import org.hibernate.annotations.Where;
+import org.springframework.util.StringUtils;
 import seong.onlinestudy.request.member.MemberCreateRequest;
+import seong.onlinestudy.request.member.MemberUpdateRequest;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -9,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Where(clause = "deleted = false")
 @Getter
 public class Member {
 
@@ -20,8 +24,9 @@ public class Member {
     private String password;
     private String nickname;
     private LocalDateTime createdAt;
+    private boolean deleted;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "member")
     private List<GroupMember> groupMembers = new ArrayList<>();
 
     @OneToMany(mappedBy = "member")
@@ -42,11 +47,16 @@ public class Member {
         }
     }
 
+    public void delete() {
+        this.deleted = true;
+    }
+
     public static Member createMember(MemberCreateRequest request) {
         Member member = new Member();
         member.username = request.getUsername();
         member.password = request.getPassword();
         member.nickname = request.getNickname();
+        member.deleted = false;
 
         return member;
     }

--- a/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
@@ -18,5 +18,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             " where gm.role='MASTER' and g in :groups")
     List<GroupMember> findGroupMasters(@Param("groups") List<Group> groups);
 
-    void deleteByMember(Member member);
+    void deleteByMemberId(Long memberId);
+
+    void deleteByGroupAndMember(Group group, Member member);
 }

--- a/src/main/java/seong/onlinestudy/request/member/MemberUpdateRequest.java
+++ b/src/main/java/seong/onlinestudy/request/member/MemberUpdateRequest.java
@@ -1,0 +1,18 @@
+package seong.onlinestudy.request.member;
+
+import lombok.Data;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Data
+public class MemberUpdateRequest {
+
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상, 12자 이아혀야 합니다.")
+    private String nickname;
+
+    @Size(min = 6, max = 20, message = "비밀번호는 6자 이상, 20자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{6,20}$",
+            message = "비밀번호는 영문, 특수문자, 숫자를 포함하여 8자 이상, 20자 이하여야 합니다.")
+    private String password;
+}

--- a/src/main/java/seong/onlinestudy/service/GroupService.java
+++ b/src/main/java/seong/onlinestudy/service/GroupService.java
@@ -137,7 +137,7 @@ public class GroupService {
         Member member = memberRepository.findById(loginMember.getId())
                 .orElseThrow(() -> new NoSuchElementException("잘못된 접근입니다."));
 
-        groupMemberRepository.deleteByMember(member);
+        groupMemberRepository.deleteByGroupAndMember(group, member);
     }
 
     @Transactional

--- a/src/main/java/seong/onlinestudy/service/MemberService.java
+++ b/src/main/java/seong/onlinestudy/service/MemberService.java
@@ -9,6 +9,7 @@ import seong.onlinestudy.exception.DuplicateElementException;
 import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.request.member.MemberCreateRequest;
 import seong.onlinestudy.request.member.MemberDuplicateCheckRequest;
+import seong.onlinestudy.request.member.MemberUpdateRequest;
 
 import java.util.NoSuchElementException;
 
@@ -38,10 +39,21 @@ public class MemberService {
                 });
     }
 
-    public MemberDto getMember(Member loginMember) {
-        Member member = memberRepository.findById(loginMember.getId())
-                .orElseThrow(() -> new NoSuchElementException("잘못된 접근입니다."));
+    public MemberDto getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
 
         return MemberDto.from(member);
     }
+
+    @Transactional
+    public Long updateMember(Long memberId, MemberUpdateRequest request) {
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+        findMember.update(request);
+
+        return findMember.getId();
+    }
+
 }

--- a/src/main/java/seong/onlinestudy/service/MemberService.java
+++ b/src/main/java/seong/onlinestudy/service/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.dto.MemberDto;
 import seong.onlinestudy.exception.DuplicateElementException;
+import seong.onlinestudy.repository.GroupMemberRepository;
 import seong.onlinestudy.repository.MemberRepository;
 import seong.onlinestudy.request.member.MemberCreateRequest;
 import seong.onlinestudy.request.member.MemberDuplicateCheckRequest;
@@ -19,6 +20,7 @@ import java.util.NoSuchElementException;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Transactional
     public Long addMember(MemberCreateRequest memberCreateRequest) {
@@ -56,4 +58,13 @@ public class MemberService {
         return findMember.getId();
     }
 
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회웝입니다."));
+
+        findMember.delete();
+
+        groupMemberRepository.deleteByMemberId(memberId);
+    }
 }


### PR DESCRIPTION
## 개요
회원 업데이트, 삭제 요청 추가

## 작업 내용
회원 업데이트, 삭제 요청 API를 추가하였습니다.
회원 삭제의 경우 @Where 애노테이션을 이용하여 soft-delete로 구현하였습니다.
회원 삭제시 연관된 그룹의 탈퇴를 위해 연관된 groupMember 를 삭제하는 메서드를 추가하였습니다.