### PR TITLE
회원 탈퇴를 위한 게시글 및 그룹 일괄 삭제, 일괄 탈퇴 요청 추가

### DIFF
--- a/src/main/java/seong/onlinestudy/controller/GroupController.java
+++ b/src/main/java/seong/onlinestudy/controller/GroupController.java
@@ -102,4 +102,28 @@ public class GroupController {
 
         return new Result<>("200", groupId);
     }
+
+    @DeleteMapping("/groups")
+    public Result<String> deleteGroups(@RequestBody @Valid GroupsDeleteRequest request,
+                                       @SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember) {
+        if(loginMember == null) {
+            throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");
+        }
+
+        groupService.deleteGroups(request, loginMember);
+
+        return new Result<>("200", "delete groups");
+    }
+
+    @DeleteMapping("/groups/quit")
+    public Result<String> quitGroups(@RequestBody @Valid GroupsDeleteRequest request,
+                                     @SessionAttribute(name = LOGIN_MEMBER, required = false) Member loginMember) {
+        if(loginMember == null) {
+            throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");
+        }
+
+        groupService.quitGroups(request, loginMember);
+
+        return new Result<>("200", "quit groups");
+    }
 }

--- a/src/main/java/seong/onlinestudy/controller/GroupsDeleteRequest.java
+++ b/src/main/java/seong/onlinestudy/controller/GroupsDeleteRequest.java
@@ -1,0 +1,12 @@
+package seong.onlinestudy.controller;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class GroupsDeleteRequest {
+
+    @NotNull(message = "회원 아이디는 필수입니다.")
+    private Long MemberId;
+}

--- a/src/main/java/seong/onlinestudy/controller/PostController.java
+++ b/src/main/java/seong/onlinestudy/controller/PostController.java
@@ -11,6 +11,7 @@ import seong.onlinestudy.dto.PostDto;
 import seong.onlinestudy.exception.InvalidSessionException;
 import seong.onlinestudy.request.post.PostCreateRequest;
 import seong.onlinestudy.request.post.PostUpdateRequest;
+import seong.onlinestudy.request.post.PostsDeleteRequest;
 import seong.onlinestudy.request.post.PostsGetRequest;
 import seong.onlinestudy.service.PostService;
 
@@ -73,5 +74,16 @@ public class PostController {
         postService.deletePost(postId, loginMember);
 
         return new Result<>("200", "delete post");
+    }
+
+    @DeleteMapping("/posts")
+    public Result<String> deletePosts(@RequestBody @Valid PostsDeleteRequest request,
+                                      @SessionAttribute(value = LOGIN_MEMBER, required = false) Member loginMember) {
+        if(loginMember == null) {
+            throw new InvalidSessionException("세션 정보가 유효하지 않습니다.");
+        }
+        postService.deletePosts(request, loginMember);
+
+        return new Result<>("200", "delete Posts");
     }
 }

--- a/src/main/java/seong/onlinestudy/domain/Group.java
+++ b/src/main/java/seong/onlinestudy/domain/Group.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.domain;
 
 import lombok.Getter;
+import org.hibernate.annotations.Where;
 import seong.onlinestudy.enumtype.GroupCategory;
 import seong.onlinestudy.request.group.GroupCreateRequest;
 import seong.onlinestudy.request.group.GroupUpdateRequest;
@@ -12,6 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Where(clause = "deleted = false")
 @Table(name = "groups")
 public class Group {
     @Id
@@ -21,6 +23,7 @@ public class Group {
     private String name;
     private int headcount;
     private LocalDateTime createdAt;
+    private boolean deleted;
 
     @Lob
     private String description;
@@ -42,6 +45,10 @@ public class Group {
         groupMember.setGroup(this);
     }
 
+    public void delete() {
+        this.deleted = true;
+    }
+
     public static Group createGroup(GroupCreateRequest createRequest, GroupMember groupMember) {
         Group group = new Group();
         group.name = createRequest.getName();
@@ -49,6 +56,7 @@ public class Group {
         group.headcount = createRequest.getHeadcount();
         group.createdAt = LocalDateTime.now();
         group.addGroupMember(groupMember);
+        group.deleted = false;
 
         return group;
     }

--- a/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupMemberRepository.java
@@ -1,12 +1,12 @@
 package seong.onlinestudy.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import seong.onlinestudy.domain.Group;
 import seong.onlinestudy.domain.GroupMember;
 import seong.onlinestudy.domain.Member;
-import seong.onlinestudy.dto.GroupMemberCountDto;
 
 import java.util.List;
 
@@ -18,7 +18,9 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             " where gm.role='MASTER' and g in :groups")
     List<GroupMember> findGroupMasters(@Param("groups") List<Group> groups);
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query("delete from GroupMember gm where gm.member.id = :memberId and gm.role <> 'MASTER'")
+    void deleteAllByMemberIdRoleIsNotMaster(@Param("memberId") Long memberId);
 
     void deleteByGroupAndMember(Group group, Member member);
 }

--- a/src/main/java/seong/onlinestudy/repository/GroupRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupRepository.java
@@ -23,5 +23,5 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     @Query("update Group g set g.deleted = true" +
             " where g in (select gm.group from GroupMember gm" +
             " where gm.member.id=:memberId and gm.role='MASTER')")
-    void softDeleteAllByMemberId(@Param("memberId") Long memberId);
+    void softDeleteAllByMemberIdRoleIsMaster(@Param("memberId") Long memberId);
 }

--- a/src/main/java/seong/onlinestudy/repository/GroupRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupRepository.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import seong.onlinestudy.domain.Group;
@@ -18,4 +19,9 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     @Query("select g from Group g join fetch g.groupMembers gm join fetch gm.member where g.id=:groupId")
     Optional<Group> findGroupWithMembers(@Param("groupId") Long groupId);
 
+    @Modifying
+    @Query("update Group g set g.deleted = true" +
+            " where g in (select gm.group from GroupMember gm" +
+            " where gm.member.id=:memberId and gm.role='MASTER')")
+    void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/seong/onlinestudy/repository/PostRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package seong.onlinestudy.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import seong.onlinestudy.domain.Post;
@@ -20,4 +21,9 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     @Query("select p from Post p left join fetch p.postStudies ps left join fetch ps.study s where p.id=:postId")
     Optional<Post> findByIdWithStudies(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("update Post p set p.deleted = true" +
+            " where p.member.id = :memberId")
+    void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/seong/onlinestudy/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/GroupRepositoryCustom.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface GroupRepositoryCustom {
 
-    Page<Group> findGroups(Pageable pageable, GroupCategory category, String search, List<Long> studyIds, OrderBy orderBy);
+    Page<Group> findGroups(Long memberId, GroupCategory category, String search, List<Long> studyIds, OrderBy orderBy, Pageable pageable);
 }

--- a/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryCustom.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryCustom.java
@@ -11,13 +11,15 @@ public interface PostRepositoryCustom {
 
     /**
      * Post 엔티티로부터 Comment, Member 엔티티를 페치 조인하고 조건에 따른 목록을 조회한다.
-     * @param pageable page, offset 데이터를 이용
+     *
+     * @param memberId Post 엔티티의 회원 조건 검색을 위한 Member 의 id
      * @param groupId Post 엔티티가 소속된 그룹 조건을 위한 Group 의 id
      * @param search like '%search%' 조건을 위한 문자열
      * @param category category 검색을 위한 PostCategory enum
      * @param studyIds Study 와 연관관계 조건을 위한 id List
+     * @param pageable page, offset 데이터를 이용
      * @return Comment, Member 와 페치 조인한 Post 목록을 반환
      * */
-    Page<Post> findPostsWithComments(Pageable pageable, Long groupId, String search, PostCategory category, List<Long> studyIds);
+    Page<Post> findPostsWithComments(Long memberId, Long groupId, String search, PostCategory category, List<Long> studyIds, Pageable pageable);
 
 }

--- a/src/main/java/seong/onlinestudy/request/group/GroupsGetRequest.java
+++ b/src/main/java/seong/onlinestudy/request/group/GroupsGetRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class GroupsGetRequest {
     private int page;
     private int size;
+    private Long memberId;
     private GroupCategory category;
     private String search;
     private List<Long> studyIds;

--- a/src/main/java/seong/onlinestudy/request/post/PostsDeleteRequest.java
+++ b/src/main/java/seong/onlinestudy/request/post/PostsDeleteRequest.java
@@ -1,0 +1,12 @@
+package seong.onlinestudy.request.post;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class PostsDeleteRequest {
+
+    @NotNull(message = "회원 아이디는 필수입니다.")
+    private Long MemberId;
+}

--- a/src/main/java/seong/onlinestudy/request/post/PostsGetRequest.java
+++ b/src/main/java/seong/onlinestudy/request/post/PostsGetRequest.java
@@ -10,6 +10,7 @@ public class PostsGetRequest {
 
     private int page;
     private int size;
+    private Long memberId;
     private Long groupId;
     private String search;
     private PostCategory category;

--- a/src/main/java/seong/onlinestudy/service/GroupService.java
+++ b/src/main/java/seong/onlinestudy/service/GroupService.java
@@ -66,8 +66,11 @@ public class GroupService {
     }
 
     public Page<GroupDto> getGroups(GroupsGetRequest request) {
-        Page<Group> groups = groupRepository.findGroups(PageRequest.of(request.getPage(), request.getSize()),
-                request.getCategory(), request.getSearch(), request.getStudyIds(), request.getOrderBy());
+        PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
+        Page<Group> groups = groupRepository.findGroups(
+                request.getMemberId(), request.getCategory(),
+                request.getSearch(), request.getStudyIds(),
+                request.getOrderBy(), pageRequest);
 
         List<GroupStudyDto> groupStudies = studyRepository.findStudiesInGroups(groups.getContent());
 

--- a/src/main/java/seong/onlinestudy/service/GroupService.java
+++ b/src/main/java/seong/onlinestudy/service/GroupService.java
@@ -120,16 +120,19 @@ public class GroupService {
 
     @Transactional
     public void deleteGroup(Long id, Member loginMember) {
-        Group group = groupRepository.findById(id)
+        Group group = groupRepository.findGroupWithMembers(id)
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 그룹입니다."));
 
-        GroupMember master = group.getGroupMembers().stream().filter(groupMember ->
-                groupMember.getRole().equals(MASTER)).findFirst().get();
+        GroupMember master = group.getGroupMembers().stream()
+                .filter(groupMember -> groupMember.getRole().equals(MASTER))
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("그룹장이 존재하지 않습니다."));
+
         if(!master.getMember().getId().equals(loginMember.getId())) {
             throw new PermissionControlException("권한이 없습니다.");
         }
 
-        groupRepository.delete(group);
+        group.delete();
     }
 
     @Transactional

--- a/src/main/java/seong/onlinestudy/service/GroupService.java
+++ b/src/main/java/seong/onlinestudy/service/GroupService.java
@@ -171,7 +171,7 @@ public class GroupService {
             throw new PermissionControlException("권한이 없습니다.");
         }
 
-        groupRepository.softDeleteAllByMemberId(request.getMemberId());
+        groupRepository.softDeleteAllByMemberIdRoleIsMaster(request.getMemberId());
     }
 
     @Transactional

--- a/src/main/java/seong/onlinestudy/service/GroupService.java
+++ b/src/main/java/seong/onlinestudy/service/GroupService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import seong.onlinestudy.controller.GroupsDeleteRequest;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.GroupDto;
 import seong.onlinestudy.dto.GroupMemberDto;
@@ -162,5 +163,23 @@ public class GroupService {
         group.update(request);
 
         return group.getId();
+    }
+
+    @Transactional
+    public void deleteGroups(GroupsDeleteRequest request, Member loginMember) {
+        if(!request.getMemberId().equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
+        }
+
+        groupRepository.softDeleteAllByMemberId(request.getMemberId());
+    }
+
+    @Transactional
+    public void quitGroups(GroupsDeleteRequest request, Member loginMember) {
+        if(!request.getMemberId().equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
+        }
+
+        groupMemberRepository.deleteAllByMemberIdRoleIsNotMaster(request.getMemberId());
     }
 }

--- a/src/main/java/seong/onlinestudy/service/MemberService.java
+++ b/src/main/java/seong/onlinestudy/service/MemberService.java
@@ -65,6 +65,6 @@ public class MemberService {
 
         findMember.delete();
 
-        groupMemberRepository.deleteByMemberId(memberId);
+        groupMemberRepository.deleteAllByMemberIdRoleIsNotMaster(memberId);
     }
 }

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -31,9 +31,10 @@ public class PostService {
     public Page<PostDto> getPosts(PostsGetRequest request) {
         PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
         Page<Post> postsWithComments
-                = postRepository.findPostsWithComments(pageRequest,
-                request.getGroupId(), request.getSearch(), request.getCategory(),
-                request.getStudyIds());
+                = postRepository.findPostsWithComments(
+                        request.getMemberId(), request.getGroupId(),
+                        request.getSearch(), request.getCategory(),
+                        request.getStudyIds(), pageRequest);
 
         List<PostStudy> postStudies = postStudyRepository.findStudiesWhereInPosts(postsWithComments.getContent());
 

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -12,6 +12,7 @@ import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.repository.*;
 import seong.onlinestudy.request.post.PostCreateRequest;
 import seong.onlinestudy.request.post.PostUpdateRequest;
+import seong.onlinestudy.request.post.PostsDeleteRequest;
 import seong.onlinestudy.request.post.PostsGetRequest;
 
 import java.util.*;
@@ -140,5 +141,14 @@ public class PostService {
 
         postStudyRepository.deleteAllByPost(post);
         post.delete();
+    }
+
+    @Transactional
+    public void deletePosts(PostsDeleteRequest request, Member loginMember) {
+        if(!request.getMemberId().equals(loginMember.getId())) {
+            throw new PermissionControlException("권한이 없습니다.");
+        }
+
+        postRepository.softDeleteAllByMemberId(request.getMemberId());
     }
 }

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -41,7 +41,7 @@ public class MyUtils {
     public static List<Group> createGroups(List<Member> members, int endId) {
         List<Group> groups = new ArrayList<>();
         for(int i=0; i<endId; i++) {
-            groups.add(createGroup("테스트그룹" + 1, 30, members.get(i)));
+            groups.add(createGroup("테스트그룹" + 1, 30, members.get(i%members.size())));
         }
         return groups;
     }

--- a/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
@@ -418,6 +418,68 @@ class GroupControllerTest {
                         )));
     }
 
+    @Test
+    @DisplayName("그룹 목록 삭제")
+    void deleteGroups() throws Exception {
+        //given
+        Member loginMember = createMember("member", "member");
+        session.setAttribute(LOGIN_MEMBER, loginMember);
+
+        GroupsDeleteRequest request = new GroupsDeleteRequest();
+        request.setMemberId(1L);
+
+        //when
+        ResultActions result = mvc.perform(delete("/api/v1/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request))
+                .session(session));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("groups-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),
+                                fieldWithPath("data").type(STRING).description("짧은 메시지")
+                        )));
+    }
+
+    @Test
+    @DisplayName("그룹 목록 탈퇴")
+    void quitGroups() throws Exception {
+        //given
+        Member loginMember = createMember("member", "member");
+        session.setAttribute(LOGIN_MEMBER, loginMember);
+
+        GroupsDeleteRequest request = new GroupsDeleteRequest();
+        request.setMemberId(1L);
+
+        //when
+        ResultActions result = mvc.perform(delete("/api/v1/groups/quit")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request))
+                .session(session));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("groups-quit",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),
+                                fieldWithPath("data").type(STRING).description("짧은 메시지")
+                        )));
+    }
+
 
     private GroupDto createTestGroupDto(Group group) {
         GroupDto groupDto = GroupDto.from(group);

--- a/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
@@ -260,6 +260,7 @@ class GroupControllerTest {
                                         description("페이지"),
                                 fieldWithPath("size").type(NUMBER).attributes(getDefaultValue("12"))
                                         .description("응답 데이터 개수"),
+                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
                                 fieldWithPath("category").type(STRING).description("그룹 카테고리(Enum Type)").optional(),
                                 fieldWithPath("search").type(STRING).description("그룹 이름 검색어").optional(),
                                 fieldWithPath("studyIds").type(JsonFieldType.ARRAY).description("스터디 아이디 목록").optional(),

--- a/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
@@ -19,6 +19,7 @@ import seong.onlinestudy.enumtype.GroupCategory;
 import seong.onlinestudy.enumtype.PostCategory;
 import seong.onlinestudy.request.post.PostCreateRequest;
 import seong.onlinestudy.request.post.PostUpdateRequest;
+import seong.onlinestudy.request.post.PostsDeleteRequest;
 import seong.onlinestudy.request.post.PostsGetRequest;
 import seong.onlinestudy.service.PostService;
 
@@ -305,6 +306,36 @@ class PostControllerTest {
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("postId").description("게시글 엔티티 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),
+                                fieldWithPath("data").type(STRING).description("게시글 삭제 메시지")
+                        )));
+    }
+
+    @Test
+    void deletePosts() throws Exception {
+        //given
+        Member member = MyUtils.createMember("member", "member");
+        session.setAttribute(LOGIN_MEMBER, member);
+
+        PostsDeleteRequest request = new PostsDeleteRequest();
+        request.setMemberId(1L);
+
+        //when
+        ResultActions resultActions = mvc.perform(delete("/api/v1/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request))
+                .session(session));
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("posts-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("memberId").description("회원 엔티티 아이디")
                         ),
                         responseFields(
                                 fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),

--- a/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
@@ -99,6 +99,7 @@ class PostControllerTest {
                         requestFields(
                                 fieldWithPath("page").type(NUMBER).attributes(getDefaultValue("0")).description("페이지 번호"),
                                 fieldWithPath("size").type(NUMBER).attributes(getDefaultValue("10")).description("페이지 사이즈"),
+                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
                                 fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디").optional(),
                                 fieldWithPath("search").type(STRING).description("게시글 제목 대상 검색어").optional(),
                                 fieldWithPath("category").type(STRING).description("게시글 카테고리(Enum Type 탭 참고)").optional(),

--- a/src/test/java/seong/onlinestudy/docs/CommonDocumentationTest.java
+++ b/src/test/java/seong/onlinestudy/docs/CommonDocumentationTest.java
@@ -3,6 +3,7 @@ package seong.onlinestudy.docs;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -29,6 +30,7 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(DocumentController.class)
 @AutoConfigureRestDocs
 public class CommonDocumentationTest {

--- a/src/test/java/seong/onlinestudy/repository/GroupRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/GroupRepositoryCustomTest.java
@@ -1,6 +1,5 @@
 package seong.onlinestudy.repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +23,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static seong.onlinestudy.MyUtils.*;
-import static seong.onlinestudy.domain.QGroup.group;
 
 @Slf4j
 @DataJpaTest
@@ -89,7 +87,7 @@ class GroupRepositoryCustomTest {
         PageRequest pageRequest = PageRequest.of(0, 5);
 
         Page<Group> findGroupsWithPage = groupRepository.findGroups(
-                pageRequest, category, search, studyIds, orderBy);
+                null, category, search, studyIds, orderBy, pageRequest);
 
         List<Group> findGroups = findGroupsWithPage.getContent();
 
@@ -131,7 +129,7 @@ class GroupRepositoryCustomTest {
         //when
         PageRequest pageRequest = PageRequest.of(0, 5);
         Page<Group> findGroupsWithPage = groupRepository
-                .findGroups(pageRequest, null, null, List.of(testStudy.getId()), OrderBy.CREATEDAT);
+                .findGroups(null, null, null, List.of(testStudy.getId()), OrderBy.CREATEDAT, pageRequest);
         List<Group> findGroups = findGroupsWithPage.getContent();
 
         //then
@@ -152,15 +150,19 @@ class GroupRepositoryCustomTest {
         return filteredTickets;
     }
 
-    private BooleanExpression categoryEq(GroupCategory category) {
-        return category != null ? group.category.eq(category) : null;
-    }
+    @Test
+    void findGroups() {
+        //given
 
-    private BooleanExpression nameContains(String search) {
-        return search != null ? group.name.contains(search) : null;
-    }
 
-    private BooleanExpression studyIdsIn(QStudy studyTicket, List<Long> studyIds) {
-        return studyIds != null && studyIds.size() > 0 ? studyTicket.id.in(studyIds) : null;
+        //when
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        Page<Group> findGroupsWithPageInfo = groupRepository.findGroups(null, null, null, null, OrderBy.CREATEDAT, pageRequest);
+
+        //then
+        int findTotalPages = findGroupsWithPageInfo.getTotalPages();
+        int testTotalPages = groups.size() / 2 + 1;
+
+        assertThat(findTotalPages).isEqualTo(testTotalPages);
     }
 }

--- a/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
@@ -124,7 +124,7 @@ class GroupRepositoryTest {
         groupRepository.saveAll(testGroups);
 
         //when
-        groupRepository.softDeleteAllByMemberId(testMember.getId());
+        groupRepository.softDeleteAllByMemberIdRoleIsMaster(testMember.getId());
         em.clear();
 
         //then

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
@@ -120,7 +120,7 @@ public class PostRepositoryCustomTest {
 
         //when
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<Post> findPostsWithPage = postRepository.findPostsWithComments(pageRequest, null, "검색", null, null);
+        Page<Post> findPostsWithPage = postRepository.findPostsWithComments(null, null, "검색", null, null, pageRequest);
 
         //then
         List<Post> findPosts = findPostsWithPage.getContent();
@@ -149,7 +149,7 @@ public class PostRepositoryCustomTest {
 
         PageRequest pageRequest = PageRequest.of(0, 30);
         Page<Post> findPostsWithPage
-                = postRepository.findPostsWithComments(pageRequest, null, null, null, null);
+                = postRepository.findPostsWithComments(null, null, null, null, null, pageRequest);
 
         //then
         List<Post> findPosts = findPostsWithPage.getContent();

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
+import seong.onlinestudy.enumtype.GroupRole;
 import seong.onlinestudy.enumtype.PostCategory;
 
 import javax.persistence.EntityManager;
@@ -154,5 +155,28 @@ public class PostRepositoryTest {
         Long testPostId = testPost.getId();
 
         assertThat(findPostIds).doesNotContain(testPostId);
+    }
+
+    @Test
+    void deleteAllByMemberId() {
+        //given
+        Member testMember = members.get(0);
+
+        Group testGroup = createGroup("group", 30, testMember);
+        groupRepository.save(testGroup);
+
+        List<Post> posts = createPosts(List.of(testMember), List.of(testGroup), 30, false);
+        postRepository.saveAll(posts);
+
+        assertThat(testMember.getPosts().size()).isGreaterThanOrEqualTo(30);
+
+        //when
+        postRepository.softDeleteAllByMemberId(testMember.getId());
+        em.flush();
+        em.clear();
+
+        //then
+        testMember = memberRepository.findById(testMember.getId()).get();
+        assertThat(testMember.getPosts().size()).isEqualTo(0);
     }
 }

--- a/src/test/java/seong/onlinestudy/service/GroupServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/GroupServiceTest.java
@@ -107,7 +107,7 @@ class GroupServiceTest {
         setField(memberA, "id", 2L);
 
 
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findGroupWithMembers(1L)).willReturn(Optional.of(group));
 
         //when
         Long groupId = 1L;
@@ -131,7 +131,7 @@ class GroupServiceTest {
         setField(master, "id", 1L);
         setField(memberA, "id", 2L);
 
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findGroupWithMembers(1L)).willReturn(Optional.of(group));
 
         //when
         Long groupId = 1L;
@@ -165,7 +165,7 @@ class GroupServiceTest {
 
         PageImpl<Group> testGroupsWtihPage = new PageImpl<>(testGroups, PageRequest.of(0, 5), 3);
 
-        given(groupRepository.findGroups(any(), any(), any(), any(), any()))
+        given(groupRepository.findGroups(any(), any(), any(), any(), any(), any()))
                 .willReturn(testGroupsWtihPage);
         given(studyRepository.findStudiesInGroups(any()))
                 .willReturn(testGroupStudyDtos);

--- a/src/test/java/seong/onlinestudy/service/PostServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/PostServiceTest.java
@@ -138,7 +138,7 @@ class PostServiceTest {
 
 
         List<Post> subList = posts.subList(0, 10);
-        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any()))
+        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any(), any()))
                 .willReturn(new PageImpl<>(subList, PageRequest.of(page, size), posts.size()));
 
         //when
@@ -173,7 +173,7 @@ class PostServiceTest {
 
         PostsGetRequest request = new PostsGetRequest();
 
-        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any()))
+        given(postRepository.findPostsWithComments(any(), any(), any(), any(), any(), any()))
                 .willReturn(new PageImpl<>(posts, PageRequest.of(page, size), posts.size()));
         given(postStudyRepository.findStudiesWhereInPosts(anyList()))
                 .willReturn(postStudies);


### PR DESCRIPTION
## 개요
회원 탈퇴를 위한 게시글, 그룹 요청을 변경하였습니다.

## 작업 내용
게시글 목록, 회원 목록 조회시 회원 조건 조회를 추가하였습니다.
그룹 삭제를 soft-delete로 변경하였습니다.
게시글 목록 일괄 삭제, 그룹장인 그룹 일괄 삭제, 그룹 일괄 탈퇴를 추가하였습니다.