### PR TITLE
"@Where" 어노테이션 삭제로 인한 JPQL, 로직 변경

### DIFF
--- a/src/main/java/seong/onlinestudy/domain/Comment.java
+++ b/src/main/java/seong/onlinestudy/domain/Comment.java
@@ -9,7 +9,6 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Where(clause = "deleted=false")
 @Getter
 public class Comment {
 

--- a/src/main/java/seong/onlinestudy/domain/Group.java
+++ b/src/main/java/seong/onlinestudy/domain/Group.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Where(clause = "deleted = false")
 @Table(name = "study_group")
 public class Group {
     @Id

--- a/src/main/java/seong/onlinestudy/domain/Member.java
+++ b/src/main/java/seong/onlinestudy/domain/Member.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Where(clause = "deleted = false")
 @Getter
 public class Member {
 

--- a/src/main/java/seong/onlinestudy/domain/Post.java
+++ b/src/main/java/seong/onlinestudy/domain/Post.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Where(clause = "deleted=false")
 @Getter
 public class Post {
 

--- a/src/main/java/seong/onlinestudy/dto/PostDto.java
+++ b/src/main/java/seong/onlinestudy/dto/PostDto.java
@@ -40,6 +40,7 @@ public class PostDto {
         }
 
         postDto.comments = post.getComments().stream()
+                .filter(comment -> !comment.isDeleted())
                 .map(CommentDto::from).collect(Collectors.toList());
 
         return postDto;

--- a/src/main/java/seong/onlinestudy/repository/GroupRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/GroupRepository.java
@@ -16,7 +16,7 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
      * @param groupId
      * @return GroupMember, Member 를 페치 조인한 리스트를 반환
      */
-    @Query("select g from Group g join fetch g.groupMembers gm join fetch gm.member where g.id=:groupId")
+    @Query("select g from Group g join fetch g.groupMembers gm join fetch gm.member where g.id=:groupId and g.deleted=false")
     Optional<Group> findGroupWithMembers(@Param("groupId") Long groupId);
 
     @Modifying

--- a/src/main/java/seong/onlinestudy/repository/MemberRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/MemberRepository.java
@@ -22,13 +22,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * @return Member 리스트를 반환
      */
     @Query("select m from Member m" +
-            " join m.groupMembers gm on gm.group.id = :groupId")
+            " join m.groupMembers gm on gm.group.id = :groupId and m.deleted=false")
     List<Member> findMembersInGroup(@Param("groupId") Long groupId);
 
     @Query("select m from Member m" +
             " join m.tickets t" +
             " join t.ticketRecord r" +
-            " where t.startTime >= :startTime and t.startTime < :endTime" +
+            " where t.startTime >= :startTime and t.startTime < :endTime and m.deleted=false" +
             " group by m.id" +
             " order by sum(r.activeTime) desc ")
     Page<Member> findMembersOrderByStudyTime(@Param("startTime") LocalDateTime startTime,

--- a/src/main/java/seong/onlinestudy/repository/PostRepository.java
+++ b/src/main/java/seong/onlinestudy/repository/PostRepository.java
@@ -16,10 +16,10 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
      * @param postId Post 엔티티의 Id
      * @return Member, Group 과 페치 조인한 Post 엔티티 1개 반환
      */
-    @Query("select p from Post p left join fetch p.member m left join fetch p.group g where p.id=:postId")
+    @Query("select p from Post p left join fetch p.member m left join fetch p.group g where p.id=:postId and p.deleted=false")
     Optional<Post> findByIdWithMemberAndGroup(@Param("postId") Long postId);
 
-    @Query("select p from Post p left join fetch p.postStudies ps left join fetch ps.study s where p.id=:postId")
+    @Query("select p from Post p left join fetch p.postStudies ps left join fetch ps.study s where p.id=:postId and p.deleted=false")
     Optional<Post> findByIdWithStudies(@Param("postId") Long postId);
 
     @Modifying

--- a/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/CommentRepositoryImpl.java
@@ -32,7 +32,9 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
                 .from(comment)
                 .join(comment.member, member).fetchJoin()
                 .join(comment.post, post).fetchJoin()
-                .where(memberIdEq(member, memberId), postIdEq(post, postId))
+                .where(memberIdEq(member, memberId),
+                        postIdEq(post, postId),
+                        comment.deleted.isFalse())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
@@ -40,7 +42,9 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
         Long count = query
                 .select(comment.id.count())
                 .from(comment)
-                .where(memberIdEq(comment.member, memberId), postIdEq(comment.post, postId))
+                .where(memberIdEq(comment.member, memberId),
+                        postIdEq(comment.post, postId),
+                        comment.deleted.isFalse())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetchOne();

--- a/src/main/java/seong/onlinestudy/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/GroupRepositoryImpl.java
@@ -46,7 +46,11 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom{
                 .join(group.groupMembers, groupMember)
                 .leftJoin(group.tickets, ticket)
                 .leftJoin(studyTicket).on(studyTicket.eq(ticket))
-                .where(memberIdEq(groupMember.member, memberId), categoryEq(category), nameContains(search), studyIdsIn(studyTicket.study, studyIds))
+                .where(memberIdEq(groupMember.member, memberId),
+                        categoryEq(category),
+                        nameContains(search),
+                        studyIdsIn(studyTicket.study, studyIds),
+                        group.deleted.isFalse())
                 .groupBy(group.id)
                 .orderBy(order)
                 .limit(pageable.getPageSize())
@@ -59,7 +63,11 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom{
                 .join(group.groupMembers, groupMember)
                 .leftJoin(group.tickets, ticket)
                 .leftJoin(studyTicket).on(studyTicket.eq(ticket))
-                .where(memberIdEq(groupMember.member, memberId), categoryEq(category), nameContains(search), studyIdsIn(studyTicket.study, studyIds))
+                .where(memberIdEq(groupMember.member, memberId),
+                        categoryEq(category),
+                        nameContains(search),
+                        studyIdsIn(studyTicket.study, studyIds),
+                        group.deleted.isFalse())
                 .fetchOne();
 
         return new PageImpl<>(groups, pageable, total);

--- a/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
+++ b/src/main/java/seong/onlinestudy/repository/querydsl/PostRepositoryImpl.java
@@ -39,7 +39,12 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .leftJoin(post.member, member).fetchJoin()
                 .leftJoin(post.group, group).fetchJoin()
                 .leftJoin(post.postStudies, postStudy)
-                .where(memberIdEq(memberId), groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds))
+                .where(memberIdEq(memberId),
+                        groupIdEq(groupId),
+                        searchContains(search),
+                        categoryEq(category),
+                        studyIdIn(studyIds),
+                        post.deleted.isFalse())
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .orderBy(order)
@@ -49,7 +54,12 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .select(post.countDistinct())
                 .from(post)
                 .leftJoin(post.postStudies, postStudy)
-                .where(memberIdEq(memberId), groupIdEq(groupId), searchContains(search), categoryEq(category), studyIdIn(studyIds))
+                .where(memberIdEq(memberId),
+                        groupIdEq(groupId),
+                        searchContains(search),
+                        categoryEq(category),
+                        studyIdIn(studyIds),
+                        post.deleted.isFalse())
                 .fetchOne();
 
 

--- a/src/main/java/seong/onlinestudy/service/PostService.java
+++ b/src/main/java/seong/onlinestudy/service/PostService.java
@@ -33,9 +33,12 @@ public class PostService {
         PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
         Page<Post> postsWithComments
                 = postRepository.findPostsWithComments(
-                        request.getMemberId(), request.getGroupId(),
-                        request.getSearch(), request.getCategory(),
-                        request.getStudyIds(), pageRequest);
+                        request.getMemberId(),
+                        request.getGroupId(),
+                        request.getSearch(),
+                        request.getCategory(),
+                        request.getStudyIds(),
+                        pageRequest);
 
         List<PostStudy> postStudies = postStudyRepository.findStudiesWhereInPosts(postsWithComments.getContent());
 

--- a/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/CommentRepositoryTest.java
@@ -87,7 +87,9 @@ class CommentRepositoryTest {
 
         //then
         testMember = memberRepository.findById(testMember.getId()).get();
-        assertThat(testMember.getComments().size()).isEqualTo(0);
+        assertThat(testMember.getComments()).allSatisfy(findComment -> {
+            assertThat(findComment.isDeleted()).isTrue();
+        });
     }
 
 }

--- a/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/GroupRepositoryTest.java
@@ -137,8 +137,9 @@ class GroupRepositoryTest {
                 .setParameter("memberId", testMember.getId())
                 .getResultList();
 
-        assertThat(findGroups).isEmpty();
-
+        assertThat(findGroups).allSatisfy(findGroup -> {
+            assertThat(findGroup.isDeleted()).isTrue();
+        });
     }
 
     @Test

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryCustomTest.java
@@ -158,7 +158,10 @@ public class PostRepositoryCustomTest {
 
         assertThat(findPostIds).doesNotContain(testPostId);
         assertThat(findPosts).allSatisfy(findPost -> {
-            assertThat(findPost.getComments().size()).isEqualTo(0);
+            assertThat(findPost.isDeleted()).isFalse();
+            assertThat(findPost.getComments()).allSatisfy(findComment -> {
+                assertThat(findComment.isDeleted()).isTrue();
+            });
         });
     }
 

--- a/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
+++ b/src/test/java/seong/onlinestudy/repository/PostRepositoryTest.java
@@ -151,10 +151,11 @@ public class PostRepositoryTest {
 
         //then
         List<Post> findPosts = postRepository.findAll();
-        List<Long> findPostIds = findPosts.stream().map(Post::getId).collect(Collectors.toList());
         Long testPostId = testPost.getId();
 
-        assertThat(findPostIds).doesNotContain(testPostId);
+        assertThat(findPosts).anySatisfy(findPost -> {
+            assertThat(findPost.isDeleted()).isTrue();
+        });
     }
 
     @Test
@@ -177,7 +178,10 @@ public class PostRepositoryTest {
 
         //then
         testMember = memberRepository.findById(testMember.getId()).get();
-        assertThat(testMember.getPosts().size()).isEqualTo(0);
+        assertThat(testMember.getPosts()).allSatisfy(findPost -> {
+                    assertThat(findPost.isDeleted()).isTrue();
+                }
+        );
     }
 
     @Test


### PR DESCRIPTION
## 개요
"@Where" 어노테이션을 사용하는 득보다 실이 많아 삭제하고, 관련 쿼리 및 로직을 수정하였습니다.

## 작업 내용
Member, Post, Comment, Group 으로부터 "@Where" 어노테이션을 삭제했습니다.
해당 repository 들의 조회용 JPQL에 deleted=false 를 추가하였습니다.
게시글 목록 조회의 경우 fetch join으로 comment 목록을 함께 가져오기에 DTO를 만들때 deleted=true 인 comment를 포함하지 않도록 조건문을 추가했습니다.
관련 test 검증 조건을 변경했습니다.