### PR TITLE
API 요청 URL 변경 및 문서 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -20,17 +20,17 @@ operation::common-page-result[snippets='response-body,response-fields']
 operation::member-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 회원 단건 조회
-`GET /api/v1/member/:memberId`
+`GET /api/v1/members/:memberId`
 
 operation::member-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 회원 업데이트
-`PATCH /api/v1/member/:memberId`
+`PATCH /api/v1/members/:memberId`
 
 operation::member-update[snippets='http-request,request-fields,http-response,response-fields']
 
 === 회원 삭제
-`DELETE /api/v1/member/:memberId`
+`DELETE /api/v1/members/:memberId`
 
 operation::member-duplicate-check[snippets='http-request,request-fields,http-response,response-fields']
 
@@ -54,7 +54,7 @@ operation::logout[snippets='http-request,http-response,response-fields']
 operation::groups-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 그룹 단건 조회
-`GET /api/v1/group/:groupId`
+`GET /api/v1/groups/:groupId`
 
 operation::group-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
@@ -64,22 +64,22 @@ operation::group-get[snippets='http-request,path-parameters,http-response,respon
 operation::group-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 그룹 업데이트
-`POST /api/v1/group/:groupId`
+`POST /api/v1/groups/:groupId`
 
 operation::group-update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 === 그룹 삭제
-`DELETE /api/v1/group/:groupId`
+`DELETE /api/v1/groups/:groupId`
 
 operation::group-delete[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 그룹 가입
-`POST /api/v1/group/:groupId/join`
+`POST /api/v1/groups/:groupId/join`
 
 operation::group-join[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 그룹 탈퇴
-`POST /api/v1/group/:groupId/quit`
+`POST /api/v1/groups/:groupId/quit`
 
 operation::group-quit[snippets='http-request,path-parameters,http-response,response-fields']
 
@@ -118,12 +118,12 @@ operation::ticket-create[snippets='http-request,request-fields,http-response,res
 operation::tickets-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 학습 티켓 단건 조회
-`GET /api/v1/ticket/:ticketId`
+`GET /api/v1/tickets/:ticketId`
 
 operation::ticket-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 학습 티켓 만료
-`PATCH /api/v1/ticket/:ticketId`
+`PATCH /api/v1/tickets/:ticketId`
 
 operation::ticket-expire[snippets='http-request,path-parameters,http-response,response-fields']
 
@@ -142,7 +142,7 @@ operation::ticket-records-get[snippets='http-request,request-parameters,http-res
 operation::posts-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 게시글 단건 조회
-`GET /api/v1/post/:postId`
+`GET /api/v1/posts/:postId`
 
 operation::post-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
@@ -152,12 +152,12 @@ operation::post-get[snippets='http-request,path-parameters,http-response,respons
 operation::post-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 게시글 업데이트
-`PATCH /api/v1/post/:postId`
+`PATCH /api/v1/posts/:postId`
 
 operation::post-update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 === 게시글 삭제
-`DELETE /api/v1/post/:postId`
+`DELETE /api/v1/posts/:postId`
 
 operation::post-delete[snippets='http-request,path-parameters,http-response,response-fields']
 
@@ -179,12 +179,12 @@ operation::comment-create[snippets='http-request,request-fields,http-response,re
 operation::comments-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 댓글 업데이트
-`UPDATE /api/v1/comment/:commentId`
+`UPDATE /api/v1/comments/:commentId`
 
 operation::comment-update[snippets='http-request,request-fields,http-response,response-fields']
 
 === 댓글 삭제
-`DELETE /api/v1/comment/:commentId`
+`DELETE /api/v1/comments/:commentId`
 
 operation::comment-delete[snippets='http-request,path-parameters,http-response,response-fields']
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,181 +15,181 @@ operation::common-page-result[snippets='response-body,response-fields']
 == 1. 회원 API
 
 === 회원 생성
-`POST /members`
+`POST /api/v1/members`
 
 operation::member-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 회원 단건 조회
-`GET /member/:memberId`
+`GET /api/v1/member/:memberId`
 
 operation::member-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 회원 업데이트
-`PATCH /member/:memberId`
+`PATCH /api/v1/member/:memberId`
 
 operation::member-update[snippets='http-request,request-fields,http-response,response-fields']
 
 === 회원 삭제
-`DELETE /member/:memberId`
+`DELETE /api/v1/member/:memberId`
 
 operation::member-duplicate-check[snippets='http-request,request-fields,http-response,response-fields']
 
 == 2. 로그인 API
 
 === 로그인
-`POST /login`
+`POST /api/v1/login`
 
 operation::login[snippets='http-request,request-fields,http-response,response-fields-data']
 
 === 로그아웃
-`POST /logout`
+`POST /api/v1/logout`
 
 operation::logout[snippets='http-request,http-response,response-fields']
 
 == 3. 그룹 API
 
 === 그룹 목록 조회
-`GET /groups`
+`GET /api/v1/groups`
 
-operation::groups-get[snippets='http-request,request-fields,http-response,response-fields']
+operation::groups-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 그룹 단건 조회
-`GET /group/:groupId`
+`GET /api/v1/group/:groupId`
 
-operation::group-get[snippets='http-request,path-parameters,http-response,response-fields']
+operation::group-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 그룹 생성
-`POST /groups`
+`POST /api/v1/groups`
 
 operation::group-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 그룹 업데이트
-`POST /group/:groupId`
+`POST /api/v1/group/:groupId`
 
 operation::group-update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 === 그룹 삭제
-`DELETE /group/:groupId`
+`DELETE /api/v1/group/:groupId`
 
 operation::group-delete[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 그룹 가입
-`POST /group/:groupId/join`
+`POST /api/v1/group/:groupId/join`
 
 operation::group-join[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 그룹 탈퇴
-`POST /group/:groupId/quit`
+`POST /api/v1/group/:groupId/quit`
 
 operation::group-quit[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 그룹 일괄 탈퇴
-`POST /groups/quit`
+`POST /api/v1/groups/quit`
 
 operation::groups-quit[snippets='http-request,request-fields,http-response,response-fields']
 
 === 그룹 일괄 삭제
-`POST /groups/delete`
+`POST /api/v1/groups/delete`
 
 operation::groups-quit[snippets='http-request,request-fields,http-response,response-fields']
 
 == 4. 학습 API
 
 === 학습 생성
-`POST /studies`
+`POST /api/v1/studies`
 
 operation::study-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 학습 목록 조회
-`GET /studies`
+`GET /api/v1/studies`
 
-operation::studies-get[snippets='http-request,request-fields,http-response,response-fields-data']
+operation::studies-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 == 5. 학습 티켓 API
 
 === 학습 티켓 발급
-`POST /tickets`
+`POST /api/v1/tickets`
 
 operation::ticket-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 학습 티켓 목록 조회
-`GET /tickets`
+`GET /api/v1/tickets`
 
-operation::tickets-get[snippets='http-request,request-fields,http-response,response-fields-data']
+operation::tickets-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 학습 티켓 단건 조회
-`GET /ticket/:ticketId`
+`GET /api/v1/ticket/:ticketId`
 
 operation::ticket-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 학습 티켓 만료
-`PATCH /ticket/:ticketId`
+`PATCH /api/v1/ticket/:ticketId`
 
 operation::ticket-expire[snippets='http-request,path-parameters,http-response,response-fields']
 
 == 6. 기록 API
 
 === 공부 기록 목록 조회
-`GET /records`
+`GET /api/v1/records`
 
-operation::ticket-records-get[snippets='http-request,request-fields,http-response,response-fields']
+operation::ticket-records-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 == 7. 게시글 API
 
 === 게시글 목록 조회
-`GET /posts`
+`GET /api/v1/posts`
 
-operation::posts-get[snippets='http-request,request-fields,http-response,response-fields-data']
+operation::posts-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 게시글 단건 조회
-`GET /post/:postId`
+`GET /api/v1/post/:postId`
 
 operation::post-get[snippets='http-request,path-parameters,http-response,response-fields-data']
 
 === 게시글 생성
-`POST /posts`
+`POST /api/v1/posts`
 
 operation::post-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 게시글 업데이트
-`PATCH /post/:postId`
+`PATCH /api/v1/post/:postId`
 
 operation::post-update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
 
 === 게시글 삭제
-`DELETE /post/:postId`
+`DELETE /api/v1/post/:postId`
 
 operation::post-delete[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 게시글 일괄 삭제
-`POST /posts/delete`
+`POST /api/v1/posts/delete`
 
 operation::posts-delete[snippets='http-request,request-fields,http-response,response-fields']
 
 == 8. 댓글 API
 
 === 댓글 생성
-`POST /comments`
+`POST /api/v1/comments`
 
 operation::comment-create[snippets='http-request,request-fields,http-response,response-fields']
 
 === 댓글 목록 조회
-`GET /comments`
+`GET /api/v1/comments`
 
 operation::comments-get[snippets='http-request,request-parameters,http-response,response-fields-data']
 
 === 댓글 업데이트
-`UPDATE /comment/:commentId`
+`UPDATE /api/v1/comment/:commentId`
 
 operation::comment-update[snippets='http-request,request-fields,http-response,response-fields']
 
 === 댓글 삭제
-`DELETE /comment/:commentId`
+`DELETE /api/v1/comment/:commentId`
 
 operation::comment-delete[snippets='http-request,path-parameters,http-response,response-fields']
 
 === 댓글 일괄 삭제
-`POST /comments/delete`
+`POST /api/v1/comments/delete`
 
 operation::comments-delete[snippets='http-request,request-fields,http-response,response-fields']
 

--- a/src/main/java/seong/onlinestudy/controller/CommentController.java
+++ b/src/main/java/seong/onlinestudy/controller/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
         return new PageResult<>("200", commentsWithPage.getContent(), commentsWithPage);
     }
 
-    @PatchMapping("/comment/{commentId}")
+    @PatchMapping("/comments/{commentId}")
     public Result<Long> updateComment(@PathVariable("commentId") Long commentId, @RequestBody @Valid CommentUpdateRequest request,
                                       @SessionAttribute(value = LOGIN_MEMBER, required = false) Long memberId) {
         if (memberId == null) {
@@ -59,7 +59,7 @@ public class CommentController {
         return new Result<>("200", updateCommentId);
     }
 
-    @DeleteMapping("/comment/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public Result<Long> deleteComment(@PathVariable("commentId") Long commentId,
                                         @SessionAttribute(value = LOGIN_MEMBER, required = false) Long memberId) {
         if (memberId == null) {

--- a/src/main/java/seong/onlinestudy/controller/GroupController.java
+++ b/src/main/java/seong/onlinestudy/controller/GroupController.java
@@ -40,7 +40,7 @@ public class GroupController {
         return new Result<>("201", groupId);
     }
 
-    @PostMapping("/group/{groupId}/join")
+    @PostMapping("/groups/{groupId}/join")
     @ResponseStatus(value = HttpStatus.CREATED)
     public Result<Long> joinGroup(@PathVariable Long groupId,
                           @SessionAttribute(name = LOGIN_MEMBER, required = false) Long memberId) {
@@ -53,7 +53,7 @@ public class GroupController {
         return new Result<>("201", joinedGroupId);
     }
 
-    @PostMapping("/group/{groupId}/quit")
+    @PostMapping("/groups/{groupId}/quit")
     public Result<String> quitGroup(@PathVariable Long groupId,
                                   @SessionAttribute(name = LOGIN_MEMBER, required = false) Long memberId) {
         if(memberId == null) {
@@ -72,14 +72,14 @@ public class GroupController {
         return new PageResult<>("200", groupsWithPageInfo.getContent(), groupsWithPageInfo);
     }
 
-    @GetMapping("/group/{id}")
+    @GetMapping("/groups/{id}")
     public Result<GroupDto> getGroup(@PathVariable Long id) {
         GroupDto group = groupService.getGroup(id);
 
         return new Result<>("200", group);
     }
 
-    @DeleteMapping("/group/{id}")
+    @DeleteMapping("/groups/{id}")
     public Result<String> deleteGroup(@PathVariable Long id,
                                       @SessionAttribute(name = LOGIN_MEMBER, required = false) Long memberId) {
         if(memberId == null) {
@@ -90,7 +90,7 @@ public class GroupController {
         return new Result<>("200", "deleted");
     }
 
-    @PostMapping("/group/{id}")
+    @PostMapping("/groups/{id}")
     public Result<Long> updateGroup(@PathVariable Long id,
                                     @RequestBody @Valid GroupUpdateRequest request,
                                     @SessionAttribute(name = LOGIN_MEMBER, required = false) Long memberId) {

--- a/src/main/java/seong/onlinestudy/controller/MemberController.java
+++ b/src/main/java/seong/onlinestudy/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
         return new Result<>("201", memberId);
     }
 
-    @GetMapping("/member/{memberId}")
+    @GetMapping("/members/{memberId}")
     public Result<MemberDto> getMember(@PathVariable Long memberId,
                                        @SessionAttribute(value = LOGIN_MEMBER, required = false) Long sessionMemberId) {
         if (sessionMemberId == null) {
@@ -53,7 +53,7 @@ public class MemberController {
         return new Result<>("200", false);
     }
 
-    @PatchMapping("/member/{memberId}")
+    @PatchMapping("/members/{memberId}")
     public Result<Long> updateMember(@PathVariable Long memberId, @RequestBody @Valid MemberUpdateRequest request,
                                      @SessionAttribute(value = LOGIN_MEMBER, required = false) Long sessionMemberId) {
         if (sessionMemberId == null) {
@@ -68,7 +68,7 @@ public class MemberController {
         return new Result<>("200", updatedMemberId);
     }
 
-    @DeleteMapping("/member/{memberId}")
+    @DeleteMapping("/members/{memberId}")
     public Result<Long> deleteMember(@PathVariable Long memberId,
                                      @SessionAttribute(name = LOGIN_MEMBER, required = false) Long sessiongMemberId) {
         if (sessiongMemberId == null) {

--- a/src/main/java/seong/onlinestudy/controller/PostController.java
+++ b/src/main/java/seong/onlinestudy/controller/PostController.java
@@ -45,14 +45,14 @@ public class PostController {
         return new Result<>("201", postId);
     }
 
-    @GetMapping("/post/{postId}")
+    @GetMapping("/posts/{postId}")
     public Result<PostDto> getPost(@PathVariable("postId") Long postId) {
         PostDto post = postService.getPost(postId);
 
         return new Result<>("200", post);
     }
 
-    @PatchMapping("/post/{postId}")
+    @PatchMapping("/posts/{postId}")
     public Result<Long> updatePost(@PathVariable("postId") Long postId,
                                    @RequestBody @Valid PostUpdateRequest request,
                                    @SessionAttribute(value = LOGIN_MEMBER, required = false) Long loginMemberId) {
@@ -64,7 +64,7 @@ public class PostController {
         return new Result<>("200", updatePostId);
     }
 
-    @DeleteMapping("/post/{postId}")
+    @DeleteMapping("/posts/{postId}")
     public Result<String> deletePost(@PathVariable("postId") Long postId,
                                    @SessionAttribute(value = LOGIN_MEMBER, required = false) Long loginMemberId) {
         if(loginMemberId == null) {

--- a/src/main/java/seong/onlinestudy/controller/TicketController.java
+++ b/src/main/java/seong/onlinestudy/controller/TicketController.java
@@ -45,7 +45,7 @@ public class TicketController {
         return new Result<>("201", ticketId);
     }
 
-    @PatchMapping("/ticket/{ticketId}")
+    @PatchMapping("/tickets/{ticketId}")
     public Result<Long> expiredTicket(@PathVariable("ticketId") Long ticketId,
                                       @SessionAttribute(name = LOGIN_MEMBER, required = false) Long loginMemberId) {
         if(loginMemberId == null) {
@@ -57,7 +57,7 @@ public class TicketController {
         return new Result<>("200", expiredTicketId);
     }
 
-    @GetMapping("/ticket/{ticketId}")
+    @GetMapping("/tickets/{ticketId}")
     public Result<TicketDto> getTicket(@PathVariable("ticketId") Long ticketId) {
         TicketDto ticket = ticketService.getTicket(ticketId);
 

--- a/src/main/java/seong/onlinestudy/controller/TicketMessageController.java
+++ b/src/main/java/seong/onlinestudy/controller/TicketMessageController.java
@@ -29,12 +29,12 @@ public class TicketMessageController {
     private final TicketService ticketService;
     private final TicketMessageService ticketMessageService;
 
-    @MessageMapping("/group/{id}")
+    @MessageMapping("/groups/{id}")
     public void sendTicket(@DestinationVariable("id") Long groupId, TicketMessage ticketMessage) {
         Ticket ticket = ticketRepository.findById(ticketMessage.getTicketId())
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 티켓입니다."));
 
-        template.convertAndSend("/sub/group/"+groupId, TicketDto.from(ticket));
+        template.convertAndSend("/sub/groups/"+groupId, TicketDto.from(ticket));
     }
 
     @MessageMapping("/groups")
@@ -43,6 +43,6 @@ public class TicketMessageController {
 
         MemberTicketDto memberTicket = ticketMessageService.getMemberTicket(ticketMessage);
 
-        template.convertAndSend("/sub/group/"+ticketMessage.getGroupId(), new Result<>("200", memberTicket));
+        template.convertAndSend("/sub/groups/"+ticketMessage.getGroupId(), new Result<>("200", memberTicket));
     }
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -788,13 +788,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_회원_단건_조회"><a class="link" href="#_회원_단건_조회">회원 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /api/v1/member/:memberId</code></p>
+<p><code>GET /api/v1/members/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_단건_조회_http_request"><a class="link" href="#_회원_단건_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/member/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/members/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -802,7 +802,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_회원_단건_조회_path_parameters"><a class="link" href="#_회원_단건_조회_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/member/{memberId}</caption>
+<caption class="title">Table 1. /api/v1/members/{memberId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -887,13 +887,13 @@ Content-Length: 142
 <div class="sect2">
 <h3 id="_회원_업데이트"><a class="link" href="#_회원_업데이트">회원 업데이트</a></h3>
 <div class="paragraph">
-<p><code>PATCH /api/v1/member/:memberId</code></p>
+<p><code>PATCH /api/v1/members/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_업데이트_http_request"><a class="link" href="#_회원_업데이트_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/member/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/members/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 146
 Host: localhost:8080
@@ -1021,7 +1021,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_회원_삭제"><a class="link" href="#_회원_삭제">회원 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /api/v1/member/:memberId</code></p>
+<p><code>DELETE /api/v1/members/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_삭제_http_request"><a class="link" href="#_회원_삭제_http_request">HTTP request</a></h4>
@@ -1391,7 +1391,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 761
+Content-Length: 760
 
 {
   "code" : "200",
@@ -1401,7 +1401,7 @@ Content-Length: 761
     "headcount" : 30,
     "memberSize" : 1,
     "deleted" : false,
-    "createdAt" : "2023-04-18T21:59:49.0132116",
+    "createdAt" : "2023-04-18T22:23:56.900752",
     "description" : "그룹 설명",
     "category" : "IT",
     "groupMembers" : [ {
@@ -1410,7 +1410,7 @@ Content-Length: 761
       "memberId" : 1,
       "username" : "회원 이름",
       "nickname" : "회원 닉네임",
-      "joinedAt" : "2023-04-18T21:59:49.0147172",
+      "joinedAt" : "2023-04-18T22:23:56.9017514",
       "role" : "MASTER"
     } ],
     "studies" : [ {
@@ -1557,13 +1557,13 @@ Content-Length: 761
 <div class="sect2">
 <h3 id="_그룹_단건_조회"><a class="link" href="#_그룹_단건_조회">그룹 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /api/v1/group/:groupId</code></p>
+<p><code>GET /api/v1/groups/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_단건_조회_http_request"><a class="link" href="#_그룹_단건_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/group/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/groups/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1571,7 +1571,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_그룹_단건_조회_path_parameters"><a class="link" href="#_그룹_단건_조회_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/group/{groupId}</caption>
+<caption class="title">Table 1. /api/v1/groups/{groupId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1609,7 +1609,7 @@ Content-Length: 655
     "headcount" : 30,
     "memberSize" : 1,
     "deleted" : false,
-    "createdAt" : "2023-04-18T21:59:49.0792857",
+    "createdAt" : "2023-04-18T22:23:56.9721235",
     "description" : "그룹 설명",
     "category" : "IT",
     "groupMembers" : [ {
@@ -1618,7 +1618,7 @@ Content-Length: 655
       "memberId" : 1,
       "username" : "회원 이름",
       "nickname" : "회원 닉네임",
-      "joinedAt" : "2023-04-18T21:59:49.0792857",
+      "joinedAt" : "2023-04-18T22:23:56.9721235",
       "role" : "MASTER"
     } ],
     "studies" : [ {
@@ -1884,13 +1884,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_업데이트"><a class="link" href="#_그룹_업데이트">그룹 업데이트</a></h3>
 <div class="paragraph">
-<p><code>POST /api/v1/group/:groupId</code></p>
+<p><code>POST /api/v1/groups/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_업데이트_http_request"><a class="link" href="#_그룹_업데이트_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/group/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/groups/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 60
 Host: localhost:8080
@@ -1905,7 +1905,7 @@ Host: localhost:8080
 <div class="sect3">
 <h4 id="_그룹_업데이트_path_parameters"><a class="link" href="#_그룹_업데이트_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/group/{groupId}</caption>
+<caption class="title">Table 1. /api/v1/groups/{groupId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2020,13 +2020,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_삭제"><a class="link" href="#_그룹_삭제">그룹 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /api/v1/group/:groupId</code></p>
+<p><code>DELETE /api/v1/groups/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_삭제_http_request"><a class="link" href="#_그룹_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/group/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/groups/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2034,7 +2034,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_그룹_삭제_path_parameters"><a class="link" href="#_그룹_삭제_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/group/{groupId}</caption>
+<caption class="title">Table 1. /api/v1/groups/{groupId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2104,13 +2104,13 @@ Content-Length: 45
 <div class="sect2">
 <h3 id="_그룹_가입"><a class="link" href="#_그룹_가입">그룹 가입</a></h3>
 <div class="paragraph">
-<p><code>POST /api/v1/group/:groupId/join</code></p>
+<p><code>POST /api/v1/groups/:groupId/join</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_가입_http_request"><a class="link" href="#_그룹_가입_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/group/1/join HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/groups/1/join HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2118,7 +2118,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_그룹_가입_path_parameters"><a class="link" href="#_그룹_가입_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/group/{groupId}/join</caption>
+<caption class="title">Table 1. /api/v1/groups/{groupId}/join</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2188,13 +2188,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_탈퇴"><a class="link" href="#_그룹_탈퇴">그룹 탈퇴</a></h3>
 <div class="paragraph">
-<p><code>POST /api/v1/group/:groupId/quit</code></p>
+<p><code>POST /api/v1/groups/:groupId/quit</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_탈퇴_http_request"><a class="link" href="#_그룹_탈퇴_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/group/1/quit HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/groups/1/quit HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2202,7 +2202,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_그룹_탈퇴_path_parameters"><a class="link" href="#_그룹_탈퇴_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/group/{groupId}/quit</caption>
+<caption class="title">Table 1. /api/v1/groups/{groupId}/quit</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2909,7 +2909,7 @@ Content-Length: 1007
       "ticketId" : 3,
       "status" : "STUDY",
       "activeTime" : 0,
-      "startTime" : "2023-04-18T21:59:52.8363479",
+      "startTime" : "2023-04-18T22:24:00.8238691",
       "expired" : false,
       "study" : {
         "studyId" : 1,
@@ -2920,8 +2920,8 @@ Content-Length: 1007
       "ticketId" : 1,
       "status" : "STUDY",
       "activeTime" : 3600,
-      "startTime" : "2023-04-18T21:59:52.8363479",
-      "endTime" : "2023-04-18T22:59:52.8363479",
+      "startTime" : "2023-04-18T22:24:00.8238691",
+      "endTime" : "2023-04-18T23:24:00.8238691",
       "expired" : true,
       "study" : {
         "studyId" : 1,
@@ -2931,8 +2931,8 @@ Content-Length: 1007
       "ticketId" : 2,
       "status" : "STUDY",
       "activeTime" : 500,
-      "startTime" : "2023-04-18T21:59:52.8363479",
-      "endTime" : "2023-04-18T22:08:12.8363479",
+      "startTime" : "2023-04-18T22:24:00.8238691",
+      "endTime" : "2023-04-18T22:32:20.8238691",
       "expired" : true,
       "study" : {
         "studyId" : 1,
@@ -3068,13 +3068,13 @@ Content-Length: 1007
 <div class="sect2">
 <h3 id="_학습_티켓_단건_조회"><a class="link" href="#_학습_티켓_단건_조회">학습 티켓 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /api/v1/ticket/:ticketId</code></p>
+<p><code>GET /api/v1/tickets/:ticketId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_단건_조회_http_request"><a class="link" href="#_학습_티켓_단건_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/ticket/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/tickets/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3082,7 +3082,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_학습_티켓_단건_조회_path_parameters"><a class="link" href="#_학습_티켓_단건_조회_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/ticket/{ticketId}</caption>
+<caption class="title">Table 1. /api/v1/tickets/{ticketId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3110,7 +3110,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 259
+Content-Length: 258
 
 {
   "code" : "200",
@@ -3118,7 +3118,7 @@ Content-Length: 259
     "ticketId" : 1,
     "status" : "STUDY",
     "activeTime" : 0,
-    "startTime" : "2023-04-18T21:59:52.8593871",
+    "startTime" : "2023-04-18T22:24:00.850933",
     "expired" : false,
     "study" : {
       "studyId" : 1,
@@ -3197,13 +3197,13 @@ Content-Length: 259
 <div class="sect2">
 <h3 id="_학습_티켓_만료"><a class="link" href="#_학습_티켓_만료">학습 티켓 만료</a></h3>
 <div class="paragraph">
-<p><code>PATCH /api/v1/ticket/:ticketId</code></p>
+<p><code>PATCH /api/v1/tickets/:ticketId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_만료_http_request"><a class="link" href="#_학습_티켓_만료_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/ticket/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/tickets/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3211,7 +3211,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_학습_티켓_만료_path_parameters"><a class="link" href="#_학습_티켓_만료_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/ticket/{ticketId}</caption>
+<caption class="title">Table 1. /api/v1/tickets/{ticketId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3353,8 +3353,8 @@ Content-Length: 333
     "memberCount" : 1,
     "records" : [ {
       "date" : "2023-04-18",
-      "startTime" : "2023-04-18T20:59:56.0592516",
-      "endTime" : "2023-04-18T22:59:56.0592516",
+      "startTime" : "2023-04-18T21:24:04.3189873",
+      "endTime" : "2023-04-18T23:24:04.3189873",
       "studyTime" : 0,
       "memberCount" : 1
     } ]
@@ -3510,7 +3510,7 @@ Content-Length: 1239
     "title" : "제목",
     "content" : "내용",
     "category" : "CHAT",
-    "createdAt" : "2023-04-18T21:59:51.4286918",
+    "createdAt" : "2023-04-18T22:23:59.3574579",
     "viewCount" : 1,
     "deleted" : false,
     "member" : {
@@ -3525,7 +3525,7 @@ Content-Length: 1239
       "headcount" : 30,
       "memberSize" : 0,
       "deleted" : false,
-      "createdAt" : "2023-04-18T21:59:51.4286918",
+      "createdAt" : "2023-04-18T22:23:59.3574579",
       "description" : "그룹 설명",
       "category" : "IT",
       "groupMembers" : [ ],
@@ -3545,7 +3545,7 @@ Content-Length: 1239
         "nickname" : "member",
         "deleted" : false
       },
-      "createdAt" : "2023-04-18T21:59:51.4286918",
+      "createdAt" : "2023-04-18T22:23:59.3574579",
       "postId" : 1,
       "deleted" : false
     } ]
@@ -3737,13 +3737,13 @@ Content-Length: 1239
 <div class="sect2">
 <h3 id="_게시글_단건_조회"><a class="link" href="#_게시글_단건_조회">게시글 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /api/v1/post/:postId</code></p>
+<p><code>GET /api/v1/posts/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_단건_조회_http_request"><a class="link" href="#_게시글_단건_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/post/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/posts/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3751,7 +3751,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_게시글_단건_조회_path_parameters"><a class="link" href="#_게시글_단건_조회_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/post/{postId}</caption>
+<caption class="title">Table 1. /api/v1/posts/{postId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3788,7 +3788,7 @@ Content-Length: 1133
     "title" : "제목",
     "content" : "내용",
     "category" : "CHAT",
-    "createdAt" : "2023-04-18T21:59:51.3671168",
+    "createdAt" : "2023-04-18T22:23:59.2918334",
     "viewCount" : 1,
     "deleted" : false,
     "member" : {
@@ -3803,7 +3803,7 @@ Content-Length: 1133
       "headcount" : 30,
       "memberSize" : 0,
       "deleted" : false,
-      "createdAt" : "2023-04-18T21:59:51.3671168",
+      "createdAt" : "2023-04-18T22:23:59.2918334",
       "description" : "그룹 설명",
       "category" : "IT",
       "groupMembers" : [ ],
@@ -3823,7 +3823,7 @@ Content-Length: 1133
         "nickname" : "member",
         "deleted" : false
       },
-      "createdAt" : "2023-04-18T21:59:51.3671168",
+      "createdAt" : "2023-04-18T22:23:59.2918334",
       "postId" : 1,
       "deleted" : false
     } ]
@@ -4154,13 +4154,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_게시글_업데이트"><a class="link" href="#_게시글_업데이트">게시글 업데이트</a></h3>
 <div class="paragraph">
-<p><code>PATCH /api/v1/post/:postId</code></p>
+<p><code>PATCH /api/v1/posts/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_업데이트_http_request"><a class="link" href="#_게시글_업데이트_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/post/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/posts/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 127
 Host: localhost:8080
@@ -4177,7 +4177,7 @@ Host: localhost:8080
 <div class="sect3">
 <h4 id="_게시글_업데이트_path_parameters"><a class="link" href="#_게시글_업데이트_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/post/{postId}</caption>
+<caption class="title">Table 1. /api/v1/posts/{postId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4310,13 +4310,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_게시글_삭제"><a class="link" href="#_게시글_삭제">게시글 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /api/v1/post/:postId</code></p>
+<p><code>DELETE /api/v1/posts/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_삭제_http_request"><a class="link" href="#_게시글_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/post/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/posts/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -4324,7 +4324,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_게시글_삭제_path_parameters"><a class="link" href="#_게시글_삭제_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/post/{postId}</caption>
+<caption class="title">Table 1. /api/v1/posts/{postId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4683,7 +4683,7 @@ Content-Length: 430
       "nickname" : "member",
       "deleted" : false
     },
-    "createdAt" : "2023-04-18T21:59:48.1002275",
+    "createdAt" : "2023-04-18T22:23:55.9239363",
     "postId" : 1,
     "deleted" : false
   } ],
@@ -4764,13 +4764,13 @@ Content-Length: 430
 <div class="sect2">
 <h3 id="_댓글_업데이트"><a class="link" href="#_댓글_업데이트">댓글 업데이트</a></h3>
 <div class="paragraph">
-<p><code>UPDATE /api/v1/comment/:commentId</code></p>
+<p><code>UPDATE /api/v1/comments/:commentId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_업데이트_http_request"><a class="link" href="#_댓글_업데이트_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/comment/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/comments/1 HTTP/1.1
 Content-Type: application/json
 Content-Length: 35
 Host: localhost:8080
@@ -4868,13 +4868,13 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_댓글_삭제"><a class="link" href="#_댓글_삭제">댓글 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /api/v1/comment/:commentId</code></p>
+<p><code>DELETE /api/v1/comments/:commentId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_삭제_http_request"><a class="link" href="#_댓글_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comment/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comments/1 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -4882,7 +4882,7 @@ Host: localhost:8080</code></pre>
 <div class="sect3">
 <h4 id="_댓글_삭제_path_parameters"><a class="link" href="#_댓글_삭제_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /api/v1/comment/{commentId}</caption>
+<caption class="title">Table 1. /api/v1/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5179,7 +5179,7 @@ Content-Length: 53
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-18 21:59:21 +0900
+Last updated 2023-04-18 22:07:39 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -654,7 +654,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_회원_생성"><a class="link" href="#_회원_생성">회원 생성</a></h3>
 <div class="paragraph">
-<p><code>POST /members</code></p>
+<p><code>POST /api/v1/members</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_생성_http_request"><a class="link" href="#_회원_생성_http_request">HTTP request</a></h4>
@@ -788,7 +788,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_회원_단건_조회"><a class="link" href="#_회원_단건_조회">회원 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /member/:memberId</code></p>
+<p><code>GET /api/v1/member/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_단건_조회_http_request"><a class="link" href="#_회원_단건_조회_http_request">HTTP request</a></h4>
@@ -887,7 +887,7 @@ Content-Length: 142
 <div class="sect2">
 <h3 id="_회원_업데이트"><a class="link" href="#_회원_업데이트">회원 업데이트</a></h3>
 <div class="paragraph">
-<p><code>PATCH /member/:memberId</code></p>
+<p><code>PATCH /api/v1/member/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_업데이트_http_request"><a class="link" href="#_회원_업데이트_http_request">HTTP request</a></h4>
@@ -1021,7 +1021,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_회원_삭제"><a class="link" href="#_회원_삭제">회원 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /member/:memberId</code></p>
+<p><code>DELETE /api/v1/member/:memberId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_회원_삭제_http_request"><a class="link" href="#_회원_삭제_http_request">HTTP request</a></h4>
@@ -1130,7 +1130,7 @@ Content-Length: 41
 <div class="sect2">
 <h3 id="_로그인"><a class="link" href="#_로그인">로그인</a></h3>
 <div class="paragraph">
-<p><code>POST /login</code></p>
+<p><code>POST /api/v1/login</code></p>
 </div>
 <div class="sect3">
 <h4 id="_로그인_http_request"><a class="link" href="#_로그인_http_request">HTTP request</a></h4>
@@ -1259,7 +1259,7 @@ Content-Length: 142
 <div class="sect2">
 <h3 id="_로그아웃"><a class="link" href="#_로그아웃">로그아웃</a></h3>
 <div class="paragraph">
-<p><code>POST /logout</code></p>
+<p><code>POST /api/v1/logout</code></p>
 </div>
 <div class="sect3">
 <h4 id="_로그아웃_http_request"><a class="link" href="#_로그아웃_http_request">HTTP request</a></h4>
@@ -1326,114 +1326,57 @@ Content-Length: 51
 <div class="sect2">
 <h3 id="_그룹_목록_조회"><a class="link" href="#_그룹_목록_조회">그룹 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /groups</code></p>
+<p><code>GET /api/v1/groups</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_목록_조회_http_request"><a class="link" href="#_그룹_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/groups HTTP/1.1
-Content-Type: application/json
-Content-Length: 162
-Host: localhost:8080
-
-{
-  "page" : 0,
-  "size" : 10,
-  "memberId" : null,
-  "category" : "IT",
-  "search" : "검색어",
-  "studyIds" : [ 1, 2, 3 ],
-  "orderBy" : "CREATEDAT"
-}</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/groups?page=0&amp;size=10&amp;category=IT&amp;search=%EA%B2%80%EC%83%89%EC%96%B4&amp;studyIds=1%2C+2%2C+3%2C+4&amp;orderBy=CREATEDAT HTTP/1.1
+Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_그룹_목록_조회_request_fields"><a class="link" href="#_그룹_목록_조회_request_fields">Request fields</a></h4>
+<h4 id="_그룹_목록_조회_request_parameters"><a class="link" href="#_그룹_목록_조회_request_parameters">Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2858%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">기본값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">12</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터 개수</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 카테고리(Enum Type)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>search</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 이름 검색어</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyIds</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 아이디 목록</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>orderBy</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">CREATEDAT</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 정렬 순서(Enum Type 탭 참고)</p></td>
 </tr>
 </tbody>
@@ -1448,7 +1391,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 760
+Content-Length: 761
 
 {
   "code" : "200",
@@ -1458,7 +1401,7 @@ Content-Length: 760
     "headcount" : 30,
     "memberSize" : 1,
     "deleted" : false,
-    "createdAt" : "2023-04-11T19:04:31.3114637",
+    "createdAt" : "2023-04-18T21:59:49.0132116",
     "description" : "그룹 설명",
     "category" : "IT",
     "groupMembers" : [ {
@@ -1467,7 +1410,7 @@ Content-Length: 760
       "memberId" : 1,
       "username" : "회원 이름",
       "nickname" : "회원 닉네임",
-      "joinedAt" : "2023-04-11T19:04:31.312464",
+      "joinedAt" : "2023-04-18T21:59:49.0147172",
       "role" : "MASTER"
     } ],
     "studies" : [ {
@@ -1487,7 +1430,7 @@ Content-Length: 760
 </div>
 </div>
 <div class="sect3">
-<h4 id="_그룹_목록_조회_response_fields"><a class="link" href="#_그룹_목록_조회_response_fields">Response fields</a></h4>
+<h4 id="_그룹_목록_조회_response_fields-data"><a class="link" href="#_그룹_목록_조회_response_fields-data">Response fields-data</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1503,142 +1446,107 @@ Content-Length: 760
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 상태 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 목록</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지의 원소 개수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>totalPages</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">총 페이지 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">다음 페이지 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasPrevious</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이전 페이지 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].headcount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>headcount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 제한 인원 수</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberSize</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 현제 인원 수</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 생성일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 설명</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 카테고리</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].deleted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>deleted</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 삭제여부</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹원 목록</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].groupMemberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].groupMemberId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹원 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].memberId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].username</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].joinedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].joinedAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 그룹 가입일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].groupMembers[].role</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].role</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 그룹 권한</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 스터디 목록</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studies[].studyId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].studyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studies[].groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studies[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studies[].studyTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].studyTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">총 스터디 시간</p></td>
 </tr>
@@ -1649,7 +1557,7 @@ Content-Length: 760
 <div class="sect2">
 <h3 id="_그룹_단건_조회"><a class="link" href="#_그룹_단건_조회">그룹 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /group/:groupId</code></p>
+<p><code>GET /api/v1/group/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_단건_조회_http_request"><a class="link" href="#_그룹_단건_조회_http_request">HTTP request</a></h4>
@@ -1701,7 +1609,7 @@ Content-Length: 655
     "headcount" : 30,
     "memberSize" : 1,
     "deleted" : false,
-    "createdAt" : "2023-04-11T19:04:31.3770646",
+    "createdAt" : "2023-04-18T21:59:49.0792857",
     "description" : "그룹 설명",
     "category" : "IT",
     "groupMembers" : [ {
@@ -1710,7 +1618,7 @@ Content-Length: 655
       "memberId" : 1,
       "username" : "회원 이름",
       "nickname" : "회원 닉네임",
-      "joinedAt" : "2023-04-11T19:04:31.3770646",
+      "joinedAt" : "2023-04-18T21:59:49.0792857",
       "role" : "MASTER"
     } ],
     "studies" : [ {
@@ -1725,7 +1633,7 @@ Content-Length: 655
 </div>
 </div>
 <div class="sect3">
-<h4 id="_그룹_단건_조회_response_fields"><a class="link" href="#_그룹_단건_조회_response_fields">Response fields</a></h4>
+<h4 id="_그룹_단건_조회_response_fields-data"><a class="link" href="#_그룹_단건_조회_response_fields-data">Response fields-data</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1741,117 +1649,107 @@ Content-Length: 655
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 상태 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">그룹</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.headcount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>headcount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 제한 인원 수</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberSize</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 현제 인원 수</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 생성일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 설명</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 카테고리</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.deleted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>deleted</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 사제 여부</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹원 목록</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].groupMemberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].groupMemberId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹원 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].memberId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].username</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 닉네임</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].joinedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].joinedAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 그룹 가입일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMembers[].role</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupMembers[].role</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 그룹 권한</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.studies</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 스터디 목록</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.studies[].studyId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].studyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.studies[].groupId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].groupId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.studies[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.studies[].studyTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studies[].studyTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">총 스터디 시간</p></td>
 </tr>
@@ -1862,7 +1760,7 @@ Content-Length: 655
 <div class="sect2">
 <h3 id="_그룹_생성"><a class="link" href="#_그룹_생성">그룹 생성</a></h3>
 <div class="paragraph">
-<p><code>POST /groups</code></p>
+<p><code>POST /api/v1/groups</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_생성_http_request"><a class="link" href="#_그룹_생성_http_request">HTTP request</a></h4>
@@ -1986,7 +1884,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_업데이트"><a class="link" href="#_그룹_업데이트">그룹 업데이트</a></h3>
 <div class="paragraph">
-<p><code>POST /group/:groupId</code></p>
+<p><code>POST /api/v1/group/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_업데이트_http_request"><a class="link" href="#_그룹_업데이트_http_request">HTTP request</a></h4>
@@ -2122,7 +2020,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_삭제"><a class="link" href="#_그룹_삭제">그룹 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /group/:groupId</code></p>
+<p><code>DELETE /api/v1/group/:groupId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_삭제_http_request"><a class="link" href="#_그룹_삭제_http_request">HTTP request</a></h4>
@@ -2206,7 +2104,7 @@ Content-Length: 45
 <div class="sect2">
 <h3 id="_그룹_가입"><a class="link" href="#_그룹_가입">그룹 가입</a></h3>
 <div class="paragraph">
-<p><code>POST /group/:groupId/join</code></p>
+<p><code>POST /api/v1/group/:groupId/join</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_가입_http_request"><a class="link" href="#_그룹_가입_http_request">HTTP request</a></h4>
@@ -2290,7 +2188,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_그룹_탈퇴"><a class="link" href="#_그룹_탈퇴">그룹 탈퇴</a></h3>
 <div class="paragraph">
-<p><code>POST /group/:groupId/quit</code></p>
+<p><code>POST /api/v1/group/:groupId/quit</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_탈퇴_http_request"><a class="link" href="#_그룹_탈퇴_http_request">HTTP request</a></h4>
@@ -2374,7 +2272,7 @@ Content-Length: 40
 <div class="sect2">
 <h3 id="_그룹_일괄_탈퇴"><a class="link" href="#_그룹_일괄_탈퇴">그룹 일괄 탈퇴</a></h3>
 <div class="paragraph">
-<p><code>POST /groups/quit</code></p>
+<p><code>POST /api/v1/groups/quit</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_일괄_탈퇴_http_request"><a class="link" href="#_그룹_일괄_탈퇴_http_request">HTTP request</a></h4>
@@ -2478,7 +2376,7 @@ Content-Length: 49
 <div class="sect2">
 <h3 id="_그룹_일괄_삭제"><a class="link" href="#_그룹_일괄_삭제">그룹 일괄 삭제</a></h3>
 <div class="paragraph">
-<p><code>POST /groups/delete</code></p>
+<p><code>POST /api/v1/groups/delete</code></p>
 </div>
 <div class="sect3">
 <h4 id="_그룹_일괄_삭제_http_request"><a class="link" href="#_그룹_일괄_삭제_http_request">HTTP request</a></h4>
@@ -2587,7 +2485,7 @@ Content-Length: 49
 <div class="sect2">
 <h3 id="_학습_생성"><a class="link" href="#_학습_생성">학습 생성</a></h3>
 <div class="paragraph">
-<p><code>POST /studies</code></p>
+<p><code>POST /api/v1/studies</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_생성_http_request"><a class="link" href="#_학습_생성_http_request">HTTP request</a></h4>
@@ -2691,114 +2589,57 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_학습_목록_조회"><a class="link" href="#_학습_목록_조회">학습 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /studies</code></p>
+<p><code>GET /api/v1/studies</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_목록_조회_http_request"><a class="link" href="#_학습_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/studies HTTP/1.1
-Content-Type: application/json
-Content-Length: 140
-Host: localhost:8080
-
-{
-  "name" : "스터디명",
-  "memberId" : 1,
-  "groupId" : 1,
-  "date" : "2023-04-11",
-  "days" : 7,
-  "page" : 0,
-  "size" : 10
-}</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/studies?page=0&amp;size=10&amp;name=%EC%8A%A4%ED%84%B0%EB%94%94%EB%AA%85&amp;memberId=1&amp;groupId=1&amp;date=2023-04-06&amp;days=7 HTTP/1.1
+Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_학습_목록_조회_request_fields"><a class="link" href="#_학습_목록_조회_request_fields">Request fields</a></h4>
+<h4 id="_학습_목록_조회_request_parameters"><a class="link" href="#_학습_목록_조회_request_parameters">Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2858%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">기본값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디명</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>date</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd</p></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">검색 시작 날짜</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>days</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">검색 일수(범위)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
 </tr>
 </tbody>
@@ -2868,7 +2709,7 @@ Content-Length: 196
 <div class="sect2">
 <h3 id="_학습_티켓_발급"><a class="link" href="#_학습_티켓_발급">학습 티켓 발급</a></h3>
 <div class="paragraph">
-<p><code>POST /tickets</code></p>
+<p><code>POST /api/v1/tickets</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_발급_http_request"><a class="link" href="#_학습_티켓_발급_http_request">HTTP request</a></h4>
@@ -2992,115 +2833,57 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_학습_티켓_목록_조회"><a class="link" href="#_학습_티켓_목록_조회">학습 티켓 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /tickets</code></p>
+<p><code>GET /api/v1/tickets</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_목록_조회_http_request"><a class="link" href="#_학습_티켓_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/tickets HTTP/1.1
-Content-Type: application/json
-Accept: application/json
-Content-Length: 130
-Host: localhost:8080
-
-{
-  "groupId" : 1,
-  "studyId" : 1,
-  "memberId" : 1,
-  "date" : "2023-04-11",
-  "days" : 1,
-  "page" : 0,
-  "size" : 30
-}</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/tickets?groupId=1&amp;studyId=1&amp;memberId=1&amp;date=2023-04-06&amp;days=1&amp;page=0&amp;size=10 HTTP/1.1
+Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_학습_티켓_목록_조회_request_fields"><a class="link" href="#_학습_티켓_목록_조회_request_fields">Request fields</a></h4>
+<h4 id="_학습_티켓_목록_조회_request_parameters"><a class="link" href="#_학습_티켓_목록_조회_request_parameters">Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2858%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">기본값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>date</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">오늘</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd</p></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">검색 시작 일자</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>days</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">검색 할 일수</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">30</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
 </tr>
 </tbody>
@@ -3126,7 +2909,7 @@ Content-Length: 1007
       "ticketId" : 3,
       "status" : "STUDY",
       "activeTime" : 0,
-      "startTime" : "2023-04-11T19:04:35.1256265",
+      "startTime" : "2023-04-18T21:59:52.8363479",
       "expired" : false,
       "study" : {
         "studyId" : 1,
@@ -3137,8 +2920,8 @@ Content-Length: 1007
       "ticketId" : 1,
       "status" : "STUDY",
       "activeTime" : 3600,
-      "startTime" : "2023-04-11T19:04:35.1256265",
-      "endTime" : "2023-04-11T20:04:35.1256265",
+      "startTime" : "2023-04-18T21:59:52.8363479",
+      "endTime" : "2023-04-18T22:59:52.8363479",
       "expired" : true,
       "study" : {
         "studyId" : 1,
@@ -3148,8 +2931,8 @@ Content-Length: 1007
       "ticketId" : 2,
       "status" : "STUDY",
       "activeTime" : 500,
-      "startTime" : "2023-04-11T19:04:35.1256265",
-      "endTime" : "2023-04-11T19:12:55.1256265",
+      "startTime" : "2023-04-18T21:59:52.8363479",
+      "endTime" : "2023-04-18T22:08:12.8363479",
       "expired" : true,
       "study" : {
         "studyId" : 1,
@@ -3285,7 +3068,7 @@ Content-Length: 1007
 <div class="sect2">
 <h3 id="_학습_티켓_단건_조회"><a class="link" href="#_학습_티켓_단건_조회">학습 티켓 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /ticket/:ticketId</code></p>
+<p><code>GET /api/v1/ticket/:ticketId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_단건_조회_http_request"><a class="link" href="#_학습_티켓_단건_조회_http_request">HTTP request</a></h4>
@@ -3335,7 +3118,7 @@ Content-Length: 259
     "ticketId" : 1,
     "status" : "STUDY",
     "activeTime" : 0,
-    "startTime" : "2023-04-11T19:04:35.1516585",
+    "startTime" : "2023-04-18T21:59:52.8593871",
     "expired" : false,
     "study" : {
       "studyId" : 1,
@@ -3414,7 +3197,7 @@ Content-Length: 259
 <div class="sect2">
 <h3 id="_학습_티켓_만료"><a class="link" href="#_학습_티켓_만료">학습 티켓 만료</a></h3>
 <div class="paragraph">
-<p><code>PATCH /ticket/:ticketId</code></p>
+<p><code>PATCH /api/v1/ticket/:ticketId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_학습_티켓_만료_http_request"><a class="link" href="#_학습_티켓_만료_http_request">HTTP request</a></h4>
@@ -3503,94 +3286,49 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_공부_기록_목록_조회"><a class="link" href="#_공부_기록_목록_조회">공부 기록 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /records</code></p>
+<p><code>GET /api/v1/records</code></p>
 </div>
 <div class="sect3">
 <h4 id="_공부_기록_목록_조회_http_request"><a class="link" href="#_공부_기록_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/records HTTP/1.1
-Content-Type: application/json
-Content-Length: 104
-Host: localhost:8080
-
-{
-  "studyId" : 1,
-  "groupId" : 1,
-  "memberId" : 1,
-  "startDate" : "2023-04-11",
-  "days" : 7
-}</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/records?startDate=2023-04-06&amp;days=7&amp;studyId=1&amp;groupId=1&amp;memberId=1 HTTP/1.1
+Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_공부_기록_목록_조회_request_fields"><a class="link" href="#_공부_기록_목록_조회_request_fields">Request fields</a></h4>
+<h4 id="_공부_기록_목록_조회_request_parameters"><a class="link" href="#_공부_기록_목록_조회_request_parameters">Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2858%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">기본값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">7일 전</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">yyyy-MM-dd</p></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">조회 시작 일자</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>days</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">조회 일 수</p></td>
 </tr>
 </tbody>
@@ -3614,9 +3352,9 @@ Content-Length: 333
     "studyName" : "스터디",
     "memberCount" : 1,
     "records" : [ {
-      "date" : "2023-04-11",
-      "startTime" : "2023-04-11T18:04:38.2224506",
-      "endTime" : "2023-04-11T20:04:38.2224506",
+      "date" : "2023-04-18",
+      "startTime" : "2023-04-18T20:59:56.0592516",
+      "endTime" : "2023-04-18T22:59:56.0592516",
       "studyTime" : 0,
       "memberCount" : 1
     } ]
@@ -3626,7 +3364,7 @@ Content-Length: 333
 </div>
 </div>
 <div class="sect3">
-<h4 id="_공부_기록_목록_조회_response_fields"><a class="link" href="#_공부_기록_목록_조회_response_fields">Response fields</a></h4>
+<h4 id="_공부_기록_목록_조회_response_fields-data"><a class="link" href="#_공부_기록_목록_조회_response_fields-data">Response fields-data</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3642,57 +3380,47 @@ Content-Length: 333
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 상태 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">공부 기록 목록</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studyId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].studyName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 이름</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberCount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 진행 회원 수</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">일자별 공부 기록 목록</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records[].date</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records[].date</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">공부 기록 일자</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records[].startTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records[].startTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">제일 빠른 공부 시작 시간</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records[].endTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records[].endTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">제일 마지막 공부 종료 시간</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records[].studyTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records[].studyTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">해당 일자의 총 공부 시간</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].records[].memberCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>records[].memberCount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">해당 일자의 스터디 진행 회원 수</p></td>
 </tr>
@@ -3708,114 +3436,57 @@ Content-Length: 333
 <div class="sect2">
 <h3 id="_게시글_목록_조회"><a class="link" href="#_게시글_목록_조회">게시글 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /posts</code></p>
+<p><code>GET /api/v1/posts</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_목록_조회_http_request"><a class="link" href="#_게시글_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/posts HTTP/1.1
-Content-Type: application/json
-Content-Length: 148
-Host: localhost:8080
-
-{
-  "page" : 0,
-  "size" : 10,
-  "memberId" : null,
-  "groupId" : 1,
-  "search" : "검색어",
-  "category" : "CHAT",
-  "studyIds" : [ 1 ]
-}</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/posts?groupId=1&amp;search=%EA%B2%80%EC%83%89%EC%96%B4&amp;category=CHAT&amp;studyIds=1%2C+2%2C+3&amp;page=0&amp;size=10 HTTP/1.1
+Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_게시글_목록_조회_request_fields"><a class="link" href="#_게시글_목록_조회_request_fields">Request fields</a></h4>
+<h4 id="_게시글_목록_조회_request_parameters"><a class="link" href="#_게시글_목록_조회_request_parameters">Request parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2858%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">기본값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">회원 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">그룹 엔티티 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>search</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목 대상 검색어</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 카테고리(Enum Type 탭 참고)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>studyIds</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">스터디 엔티티 아이디 목록</p></td>
 </tr>
 </tbody>
@@ -3839,7 +3510,7 @@ Content-Length: 1239
     "title" : "제목",
     "content" : "내용",
     "category" : "CHAT",
-    "createdAt" : "2023-04-11T19:04:33.7147622",
+    "createdAt" : "2023-04-18T21:59:51.4286918",
     "viewCount" : 1,
     "deleted" : false,
     "member" : {
@@ -3854,7 +3525,7 @@ Content-Length: 1239
       "headcount" : 30,
       "memberSize" : 0,
       "deleted" : false,
-      "createdAt" : "2023-04-11T19:04:33.7147622",
+      "createdAt" : "2023-04-18T21:59:51.4286918",
       "description" : "그룹 설명",
       "category" : "IT",
       "groupMembers" : [ ],
@@ -3874,7 +3545,7 @@ Content-Length: 1239
         "nickname" : "member",
         "deleted" : false
       },
-      "createdAt" : "2023-04-11T19:04:33.7147622",
+      "createdAt" : "2023-04-18T21:59:51.4286918",
       "postId" : 1,
       "deleted" : false
     } ]
@@ -4066,7 +3737,7 @@ Content-Length: 1239
 <div class="sect2">
 <h3 id="_게시글_단건_조회"><a class="link" href="#_게시글_단건_조회">게시글 단건 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /post/:postId</code></p>
+<p><code>GET /api/v1/post/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_단건_조회_http_request"><a class="link" href="#_게시글_단건_조회_http_request">HTTP request</a></h4>
@@ -4117,7 +3788,7 @@ Content-Length: 1133
     "title" : "제목",
     "content" : "내용",
     "category" : "CHAT",
-    "createdAt" : "2023-04-11T19:04:33.6467423",
+    "createdAt" : "2023-04-18T21:59:51.3671168",
     "viewCount" : 1,
     "deleted" : false,
     "member" : {
@@ -4132,7 +3803,7 @@ Content-Length: 1133
       "headcount" : 30,
       "memberSize" : 0,
       "deleted" : false,
-      "createdAt" : "2023-04-11T19:04:33.6467423",
+      "createdAt" : "2023-04-18T21:59:51.3671168",
       "description" : "그룹 설명",
       "category" : "IT",
       "groupMembers" : [ ],
@@ -4152,7 +3823,7 @@ Content-Length: 1133
         "nickname" : "member",
         "deleted" : false
       },
-      "createdAt" : "2023-04-11T19:04:33.6467423",
+      "createdAt" : "2023-04-18T21:59:51.3671168",
       "postId" : 1,
       "deleted" : false
     } ]
@@ -4339,7 +4010,7 @@ Content-Length: 1133
 <div class="sect2">
 <h3 id="_게시글_생성"><a class="link" href="#_게시글_생성">게시글 생성</a></h3>
 <div class="paragraph">
-<p><code>POST /posts</code></p>
+<p><code>POST /api/v1/posts</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_생성_http_request"><a class="link" href="#_게시글_생성_http_request">HTTP request</a></h4>
@@ -4483,7 +4154,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_게시글_업데이트"><a class="link" href="#_게시글_업데이트">게시글 업데이트</a></h3>
 <div class="paragraph">
-<p><code>PATCH /post/:postId</code></p>
+<p><code>PATCH /api/v1/post/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_업데이트_http_request"><a class="link" href="#_게시글_업데이트_http_request">HTTP request</a></h4>
@@ -4639,7 +4310,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_게시글_삭제"><a class="link" href="#_게시글_삭제">게시글 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /post/:postId</code></p>
+<p><code>DELETE /api/v1/post/:postId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_삭제_http_request"><a class="link" href="#_게시글_삭제_http_request">HTTP request</a></h4>
@@ -4723,7 +4394,7 @@ Content-Length: 49
 <div class="sect2">
 <h3 id="_게시글_일괄_삭제"><a class="link" href="#_게시글_일괄_삭제">게시글 일괄 삭제</a></h3>
 <div class="paragraph">
-<p><code>POST /posts/delete</code></p>
+<p><code>POST /api/v1/posts/delete</code></p>
 </div>
 <div class="sect3">
 <h4 id="_게시글_일괄_삭제_http_request"><a class="link" href="#_게시글_일괄_삭제_http_request">HTTP request</a></h4>
@@ -4832,7 +4503,7 @@ Content-Length: 50
 <div class="sect2">
 <h3 id="_댓글_생성"><a class="link" href="#_댓글_생성">댓글 생성</a></h3>
 <div class="paragraph">
-<p><code>POST /comments</code></p>
+<p><code>POST /api/v1/comments</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_생성_http_request"><a class="link" href="#_댓글_생성_http_request">HTTP request</a></h4>
@@ -4946,7 +4617,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_댓글_목록_조회"><a class="link" href="#_댓글_목록_조회">댓글 목록 조회</a></h3>
 <div class="paragraph">
-<p><code>GET /comments</code></p>
+<p><code>GET /api/v1/comments</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_목록_조회_http_request"><a class="link" href="#_댓글_목록_조회_http_request">HTTP request</a></h4>
@@ -5012,7 +4683,7 @@ Content-Length: 430
       "nickname" : "member",
       "deleted" : false
     },
-    "createdAt" : "2023-04-11T19:04:30.4108106",
+    "createdAt" : "2023-04-18T21:59:48.1002275",
     "postId" : 1,
     "deleted" : false
   } ],
@@ -5093,7 +4764,7 @@ Content-Length: 430
 <div class="sect2">
 <h3 id="_댓글_업데이트"><a class="link" href="#_댓글_업데이트">댓글 업데이트</a></h3>
 <div class="paragraph">
-<p><code>UPDATE /comment/:commentId</code></p>
+<p><code>UPDATE /api/v1/comment/:commentId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_업데이트_http_request"><a class="link" href="#_댓글_업데이트_http_request">HTTP request</a></h4>
@@ -5197,7 +4868,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_댓글_삭제"><a class="link" href="#_댓글_삭제">댓글 삭제</a></h3>
 <div class="paragraph">
-<p><code>DELETE /comment/:commentId</code></p>
+<p><code>DELETE /api/v1/comment/:commentId</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_삭제_http_request"><a class="link" href="#_댓글_삭제_http_request">HTTP request</a></h4>
@@ -5281,7 +4952,7 @@ Content-Length: 37
 <div class="sect2">
 <h3 id="_댓글_일괄_삭제"><a class="link" href="#_댓글_일괄_삭제">댓글 일괄 삭제</a></h3>
 <div class="paragraph">
-<p><code>POST /comments/delete</code></p>
+<p><code>POST /api/v1/comments/delete</code></p>
 </div>
 <div class="sect3">
 <h4 id="_댓글_일괄_삭제_http_request"><a class="link" href="#_댓글_일괄_삭제_http_request">HTTP request</a></h4>
@@ -5508,7 +5179,7 @@ Content-Length: 53
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-11 19:02:05 +0900
+Last updated 2023-04-18 21:59:21 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/seong/onlinestudy/controller/CommentControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/CommentControllerTest.java
@@ -175,7 +175,7 @@ class CommentControllerTest {
         given(commentService.updateComment(any(), any(), any())).willReturn(1L);
 
         //when
-        ResultActions resultActions = mvc.perform(patch("/api/v1/comment/{commentId}", 1L)
+        ResultActions resultActions = mvc.perform(patch("/api/v1/comments/{commentId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(request))
                 .session(session));
@@ -207,7 +207,7 @@ class CommentControllerTest {
         given(commentService.deleteComment(any(), any())).willReturn(1L);
 
         //when
-        ResultActions resultActions = mvc.perform(delete("/api/v1/comment/{commentId}", 1L)
+        ResultActions resultActions = mvc.perform(delete("/api/v1/comments/{commentId}", 1L)
                 .session(session));
 
         //then

--- a/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
@@ -181,7 +181,7 @@ class GroupControllerTest {
         given(groupService.joinGroup(any(), any())).willReturn(1L);
 
         //when
-        ResultActions result = mvc.perform(post("/api/v1/group/{groupId}/join", 1L)
+        ResultActions result = mvc.perform(post("/api/v1/groups/{groupId}/join", 1L)
                 .session(session));
 
         //then
@@ -207,7 +207,7 @@ class GroupControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions result = mvc.perform(post("/api/v1/group/{groupId}/quit", 1L)
+        ResultActions result = mvc.perform(post("/api/v1/groups/{groupId}/quit", 1L)
                 .session(session));
 
         //then
@@ -318,7 +318,7 @@ class GroupControllerTest {
         given(groupService.getGroup(anyLong())).willReturn(groupDto);
 
         //when
-        ResultActions result = mvc.perform(get("/api/v1/group/{groupId}", 1L));
+        ResultActions result = mvc.perform(get("/api/v1/groups/{groupId}", 1L));
 
         //then
         result.andExpect(status().isOk())
@@ -364,7 +364,7 @@ class GroupControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions result = mvc.perform(delete("/api/v1/group/{groupId}", 1L)
+        ResultActions result = mvc.perform(delete("/api/v1/groups/{groupId}", 1L)
                 .session(session));
 
         //then
@@ -394,7 +394,7 @@ class GroupControllerTest {
         request.setDescription("그룹 설명"); request.setHeadcount(30);
 
         //when
-        ResultActions result = mvc.perform(post("/api/v1/group/{groupId}", 1L)
+        ResultActions result = mvc.perform(post("/api/v1/groups/{groupId}", 1L)
                 .session(session)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(request)));

--- a/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/GroupControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.Group;
@@ -51,8 +53,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static seong.onlinestudy.MyUtils.createMember;
@@ -227,10 +228,13 @@ class GroupControllerTest {
     @DisplayName("그룹 목록 조회")
     void getGroups() throws Exception {
         //given
-        GroupsGetRequest request = new GroupsGetRequest();
-        request.setPage(0); request.setSize(10); request.setCategory(IT);
-        request.setSearch("검색어"); request.setStudyIds(List.of(1L,2L,3L));
-        request.setOrderBy(OrderBy.CREATEDAT);
+        MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+        request.add("page", "0");
+        request.add("size", "10");
+        request.add("category", "IT");
+        request.add("search", "검색어");
+        request.add("studyIds", "1, 2, 3, 4");
+        request.add("orderBy", "CREATEDAT");
 
         Member member = createMember("member", "member");
         Group group = MyUtils.createGroup("group", 30, member);
@@ -250,8 +254,7 @@ class GroupControllerTest {
 
         //when
         ResultActions result = mvc.perform(get("/api/v1/groups")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(request)));
+                .params(request));
 
         //then
         result.andExpect(status().isOk())
@@ -259,47 +262,41 @@ class GroupControllerTest {
                 .andDo(document("groups-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("page").type(NUMBER).attributes(getDefaultValue("0")).
+                        requestParameters(
+                                parameterWithName("page").attributes(getDefaultValue("0")).
                                         description("페이지"),
-                                fieldWithPath("size").type(NUMBER).attributes(getDefaultValue("12"))
+                                parameterWithName("size").attributes(getDefaultValue("12"))
                                         .description("응답 데이터 개수"),
-                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
-                                fieldWithPath("category").type(STRING).description("그룹 카테고리(Enum Type)").optional(),
-                                fieldWithPath("search").type(STRING).description("그룹 이름 검색어").optional(),
-                                fieldWithPath("studyIds").type(JsonFieldType.ARRAY).description("스터디 아이디 목록").optional(),
-                                fieldWithPath("orderBy").type(STRING).attributes(getDefaultValue("CREATEDAT"))
+                                parameterWithName("memberId").description("회원 엔티티 아이디").optional(),
+                                parameterWithName("category").description("그룹 카테고리(Enum Type)").optional(),
+                                parameterWithName("search").description("그룹 이름 검색어").optional(),
+                                parameterWithName("studyIds").description("스터디 아이디 목록").optional(),
+                                parameterWithName("orderBy").attributes(getDefaultValue("CREATEDAT"))
                                         .description("그룹 정렬 순서(Enum Type 탭 참고)")
                         ),
                         responseFields(
-                                fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),
-                                fieldWithPath("data").type(JsonFieldType.ARRAY).description("그룹 목록"),
-                                fieldWithPath("number").type(NUMBER).description("현재 페이지 번호"),
-                                fieldWithPath("size").type(NUMBER).description("페이지의 원소 개수"),
-                                fieldWithPath("totalPages").type(NUMBER).description("총 페이지 수"),
-                                fieldWithPath("hasNext").type(BOOLEAN).description("다음 페이지 여부"),
-                                fieldWithPath("hasPrevious").type(BOOLEAN).description("이전 페이지 여부"),
-                                fieldWithPath("data[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data[].name").type(STRING).description("그룹 이름"),
-                                fieldWithPath("data[].headcount").type(NUMBER).description("그룹 제한 인원 수"),
-                                fieldWithPath("data[].memberSize").type(NUMBER).description("그룹 현제 인원 수"),
-                                fieldWithPath("data[].createdAt").type(STRING).description("그룹 생성일"),
-                                fieldWithPath("data[].description").type(STRING).description("그룹 설명"),
-                                fieldWithPath("data[].category").type(STRING).description("그룹 카테고리"),
-                                fieldWithPath("data[].deleted").type(BOOLEAN).description("그룹 삭제여부"),
-                                fieldWithPath("data[].groupMembers").type(JsonFieldType.ARRAY).description("그룹원 목록"),
-                                fieldWithPath("data[].groupMembers[].groupMemberId").type(NUMBER).description("그룹원 엔티티 아이디"),
-                                fieldWithPath("data[].groupMembers[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data[].groupMembers[].memberId").type(NUMBER).description("회원 엔티티 아이디"),
-                                fieldWithPath("data[].groupMembers[].username").type(STRING).description("회원 아이디"),
-                                fieldWithPath("data[].groupMembers[].nickname").type(STRING).description("회원 닉네임"),
-                                fieldWithPath("data[].groupMembers[].joinedAt").type(STRING).description("회원 그룹 가입일"),
-                                fieldWithPath("data[].groupMembers[].role").type(STRING).description("회원 그룹 권한"),
-                                fieldWithPath("data[].studies").type(JsonFieldType.ARRAY).description("그룹 스터디 목록"),
-                                fieldWithPath("data[].studies[].studyId").type(NUMBER).description("스터디 엔티티 아이디"),
-                                fieldWithPath("data[].studies[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data[].studies[].name").type(STRING).description("스터디 이름"),
-                                fieldWithPath("data[].studies[].studyTime").type(NUMBER).description("총 스터디 시간")
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("name").type(STRING).description("그룹 이름"),
+                                fieldWithPath("headcount").type(NUMBER).description("그룹 제한 인원 수"),
+                                fieldWithPath("memberSize").type(NUMBER).description("그룹 현제 인원 수"),
+                                fieldWithPath("createdAt").type(STRING).description("그룹 생성일"),
+                                fieldWithPath("description").type(STRING).description("그룹 설명"),
+                                fieldWithPath("category").type(STRING).description("그룹 카테고리"),
+                                fieldWithPath("deleted").type(BOOLEAN).description("그룹 삭제여부"),
+                                fieldWithPath("groupMembers").type(JsonFieldType.ARRAY).description("그룹원 목록"),
+                                fieldWithPath("groupMembers[].groupMemberId").type(NUMBER).description("그룹원 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].memberId").type(NUMBER).description("회원 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].username").type(STRING).description("회원 아이디"),
+                                fieldWithPath("groupMembers[].nickname").type(STRING).description("회원 닉네임"),
+                                fieldWithPath("groupMembers[].joinedAt").type(STRING).description("회원 그룹 가입일"),
+                                fieldWithPath("groupMembers[].role").type(STRING).description("회원 그룹 권한"),
+                                fieldWithPath("studies").type(JsonFieldType.ARRAY).description("그룹 스터디 목록"),
+                                fieldWithPath("studies[].studyId").type(NUMBER).description("스터디 엔티티 아이디"),
+                                fieldWithPath("studies[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("studies[].name").type(STRING).description("스터디 이름"),
+                                fieldWithPath("studies[].studyTime").type(NUMBER).description("총 스터디 시간")
                         )));
 
     }
@@ -333,29 +330,28 @@ class GroupControllerTest {
                                 parameterWithName("groupId").description("그룹 엔티티 아이디")
                         ),
                         responseFields(
-                                fieldWithPath("code").type(STRING).description("HTTP 상태 코드"),
-                                fieldWithPath("data").type(OBJECT).description("그룹"),
-                                fieldWithPath("data.groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data.name").type(STRING).description("그룹 이름"),
-                                fieldWithPath("data.headcount").type(NUMBER).description("그룹 제한 인원 수"),
-                                fieldWithPath("data.memberSize").type(NUMBER).description("그룹 현제 인원 수"),
-                                fieldWithPath("data.createdAt").type(STRING).description("그룹 생성일"),
-                                fieldWithPath("data.description").type(STRING).description("그룹 설명"),
-                                fieldWithPath("data.category").type(STRING).description("그룹 카테고리"),
-                                fieldWithPath("data.deleted").type(BOOLEAN).description("그룹 사제 여부"),
-                                fieldWithPath("data.groupMembers").type(JsonFieldType.ARRAY).description("그룹원 목록"),
-                                fieldWithPath("data.groupMembers[].groupMemberId").type(NUMBER).description("그룹원 엔티티 아이디"),
-                                fieldWithPath("data.groupMembers[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data.groupMembers[].memberId").type(NUMBER).description("회원 엔티티 아이디"),
-                                fieldWithPath("data.groupMembers[].username").type(STRING).description("회원 아이디"),
-                                fieldWithPath("data.groupMembers[].nickname").type(STRING).description("회원 닉네임"),
-                                fieldWithPath("data.groupMembers[].joinedAt").type(STRING).description("회원 그룹 가입일"),
-                                fieldWithPath("data.groupMembers[].role").type(STRING).description("회원 그룹 권한"),
-                                fieldWithPath("data.studies").type(JsonFieldType.ARRAY).description("그룹 스터디 목록"),
-                                fieldWithPath("data.studies[].studyId").type(NUMBER).description("스터디 엔티티 아이디"),
-                                fieldWithPath("data.studies[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
-                                fieldWithPath("data.studies[].name").type(STRING).description("스터디 이름"),
-                                fieldWithPath("data.studies[].studyTime").type(NUMBER).description("총 스터디 시간")
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("name").type(STRING).description("그룹 이름"),
+                                fieldWithPath("headcount").type(NUMBER).description("그룹 제한 인원 수"),
+                                fieldWithPath("memberSize").type(NUMBER).description("그룹 현제 인원 수"),
+                                fieldWithPath("createdAt").type(STRING).description("그룹 생성일"),
+                                fieldWithPath("description").type(STRING).description("그룹 설명"),
+                                fieldWithPath("category").type(STRING).description("그룹 카테고리"),
+                                fieldWithPath("deleted").type(BOOLEAN).description("그룹 사제 여부"),
+                                fieldWithPath("groupMembers").type(JsonFieldType.ARRAY).description("그룹원 목록"),
+                                fieldWithPath("groupMembers[].groupMemberId").type(NUMBER).description("그룹원 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].memberId").type(NUMBER).description("회원 엔티티 아이디"),
+                                fieldWithPath("groupMembers[].username").type(STRING).description("회원 아이디"),
+                                fieldWithPath("groupMembers[].nickname").type(STRING).description("회원 닉네임"),
+                                fieldWithPath("groupMembers[].joinedAt").type(STRING).description("회원 그룹 가입일"),
+                                fieldWithPath("groupMembers[].role").type(STRING).description("회원 그룹 권한"),
+                                fieldWithPath("studies").type(JsonFieldType.ARRAY).description("그룹 스터디 목록"),
+                                fieldWithPath("studies[].studyId").type(NUMBER).description("스터디 엔티티 아이디"),
+                                fieldWithPath("studies[].groupId").type(NUMBER).description("그룹 엔티티 아이디"),
+                                fieldWithPath("studies[].name").type(STRING).description("스터디 이름"),
+                                fieldWithPath("studies[].studyTime").type(NUMBER).description("총 스터디 시간")
                         )));
     }
 

--- a/src/test/java/seong/onlinestudy/controller/MemberControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/MemberControllerTest.java
@@ -171,7 +171,7 @@ class MemberControllerTest {
         given(memberService.getMember(any())).willReturn(memberDto);
 
         //when
-        ResultActions resultActions = mvc.perform(get("/api/v1/member/{memberId}", 1)
+        ResultActions resultActions = mvc.perform(get("/api/v1/members/{memberId}", 1)
                 .session(session));
 
         //then
@@ -234,7 +234,7 @@ class MemberControllerTest {
         given(memberService.updateMember(any(), any())).willReturn(1L);
 
         //when
-        ResultActions resultActions = mvc.perform(patch("/api/v1/member/{memberId}", 1)
+        ResultActions resultActions = mvc.perform(patch("/api/v1/members/{memberId}", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(request))
                 .session(session));
@@ -276,7 +276,7 @@ class MemberControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions resultActions = mvc.perform(delete("/api/v1/member/{memberId}", 1)
+        ResultActions resultActions = mvc.perform(delete("/api/v1/members/{memberId}", 1)
                 .session(session));
 
         //then

--- a/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.*;
@@ -36,8 +38,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,9 +68,13 @@ class PostControllerTest {
     @Test
     public void getPosts() throws Exception {
         //given
-        PostsGetRequest request = new PostsGetRequest();
-        request.setGroupId(1L); request.setSearch("검색어");
-        request.setCategory(PostCategory.CHAT); request.setStudyIds(List.of(1L));
+        MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+        request.add("groupId", "1");
+        request.add("search", "검색어");
+        request.add("category", "CHAT");
+        request.add("studyIds", "1, 2, 3");
+        request.add("page", "0");
+        request.add("size", "10");
 
         Member member = MyUtils.createMember("member", "member");
         setField(member, "id", 1L);
@@ -84,14 +89,13 @@ class PostControllerTest {
         PostStudyDto postStudyDto = createPostStudyDto();
         postDto.setPostStudies(List.of(postStudyDto));
 
-        PageRequest pageRequest = PageRequest.of(request.getPage(), request.getSize());
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         given(postService.getPosts(any())).willReturn(new PageImpl<>(List.of(postDto), pageRequest, 1L));
 
         //when
         ResultActions resultActions = mvc.perform(get("/api/v1/posts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(request)));
+                .params(request));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -99,14 +103,14 @@ class PostControllerTest {
                 .andDo(document("posts-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("page").type(NUMBER).attributes(getDefaultValue("0")).description("페이지 번호"),
-                                fieldWithPath("size").type(NUMBER).attributes(getDefaultValue("10")).description("페이지 사이즈"),
-                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
-                                fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디").optional(),
-                                fieldWithPath("search").type(STRING).description("게시글 제목 대상 검색어").optional(),
-                                fieldWithPath("category").type(STRING).description("게시글 카테고리(Enum Type 탭 참고)").optional(),
-                                fieldWithPath("studyIds").type(ARRAY).description("스터디 엔티티 아이디 목록").optional()
+                        requestParameters(
+                                parameterWithName("page").attributes(getDefaultValue("0")).description("페이지 번호"),
+                                parameterWithName("size").attributes(getDefaultValue("10")).description("페이지 사이즈"),
+                                parameterWithName("memberId").description("회원 엔티티 아이디").optional(),
+                                parameterWithName("groupId").description("그룹 엔티티 아이디").optional(),
+                                parameterWithName("search").description("게시글 제목 대상 검색어").optional(),
+                                parameterWithName("category").description("게시글 카테고리(Enum Type 탭 참고)").optional(),
+                                parameterWithName("studyIds").description("스터디 엔티티 아이디 목록").optional()
                         ),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),

--- a/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/PostControllerTest.java
@@ -212,7 +212,7 @@ class PostControllerTest {
         given(postService.getPost(anyLong())).willReturn(postDto);
 
         //when
-        ResultActions resultActions = mvc.perform(get("/api/v1/post/{postId}", 1));
+        ResultActions resultActions = mvc.perform(get("/api/v1/posts/{postId}", 1));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -276,7 +276,7 @@ class PostControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions resultActions = mvc.perform(patch("/api/v1/post/{postId}", 1)
+        ResultActions resultActions = mvc.perform(patch("/api/v1/posts/{postId}", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsString(request))
                 .session(session));
@@ -309,7 +309,7 @@ class PostControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions resultActions = mvc.perform(delete("/api/v1/post/{postId}", 1)
+        ResultActions resultActions = mvc.perform(delete("/api/v1/posts/{postId}", 1)
                 .session(session));
 
         //then

--- a/src/test/java/seong/onlinestudy/controller/StudyControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/StudyControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import seong.onlinestudy.MyUtils;
 import seong.onlinestudy.docs.DocumentFormatGenerator;
 import seong.onlinestudy.domain.Member;
@@ -36,6 +38,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static seong.onlinestudy.SessionConst.LOGIN_MEMBER;
@@ -93,14 +97,14 @@ class StudyControllerTest {
     @Test
     void getStudies() throws Exception {
         //given
-        StudiesGetRequest request = new StudiesGetRequest();
-        request.setPage(0);
-        request.setSize(10);
-        request.setName("스터디명");
-        request.setMemberId(1L);
-        request.setGroupId(1L);
-        request.setDate(LocalDate.now());
-        request.setDays(7);
+        MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+        request.add("page", "0");
+        request.add("size", "10");
+        request.add("name", "스터디명");
+        request.add("memberId", "1");
+        request.add("groupId", "1");
+        request.add("date", "2023-04-06");
+        request.add("days", "7");
 
         StudyDto studyDto = new StudyDto();
         studyDto.setStudyId(1L); studyDto.setName("스터디명");
@@ -110,8 +114,7 @@ class StudyControllerTest {
 
         //when
         ResultActions resultActions = mvc.perform(get("/api/v1/studies")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(request)));
+                .params(request));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -119,16 +122,16 @@ class StudyControllerTest {
                 .andDo(document("studies-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("name").type(STRING).description("스터디명").optional(),
-                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
-                                fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디").optional(),
-                                fieldWithPath("date").type(STRING).attributes(getDateFormat())
+                        requestParameters(
+                                parameterWithName("name").description("스터디명").optional(),
+                                parameterWithName("memberId").description("회원 엔티티 아이디").optional(),
+                                parameterWithName("groupId").description("그룹 엔티티 아이디").optional(),
+                                parameterWithName("date").attributes(getDateFormat())
                                         .description("검색 시작 날짜").optional(),
-                                fieldWithPath("days").type(NUMBER).description("검색 일수(범위)").optional(),
-                                fieldWithPath("page").type(NUMBER).attributes(getDefaultValue("0"))
+                                parameterWithName("days").description("검색 일수(범위)").optional(),
+                                parameterWithName("page").attributes(getDefaultValue("0"))
                                         .description("페이지 번호"),
-                                fieldWithPath("size").type(NUMBER).attributes(getDefaultValue("10")).
+                                parameterWithName("size").attributes(getDefaultValue("10")).
                                         description("페이지 사이즈")
                         ),
                         responseFields(

--- a/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
@@ -164,7 +164,7 @@ class TicketControllerTest {
         given(ticketService.getTicket(anyLong())).willReturn(testTicketDto);
 
         //when
-        ResultActions resultActions = mvc.perform(get("/api/v1/ticket/{ticketId}", 1));
+        ResultActions resultActions = mvc.perform(get("/api/v1/tickets/{ticketId}", 1));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -250,7 +250,7 @@ class TicketControllerTest {
         session.setAttribute(LOGIN_MEMBER, 1L);
 
         //when
-        ResultActions resultActions = mvc.perform(RestDocumentationRequestBuilders.patch("/api/v1/ticket/{ticketId}", 1L)
+        ResultActions resultActions = mvc.perform(RestDocumentationRequestBuilders.patch("/api/v1/tickets/{ticketId}", 1L)
                 .session(session));
 
         //then

--- a/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.dto.MemberTicketDto;
 import seong.onlinestudy.dto.TicketDto;
@@ -35,8 +37,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,9 +69,14 @@ class TicketControllerTest {
     @Test
     public void getTickets() throws Exception {
         //given
-        TicketGetRequest request = new TicketGetRequest();
-        request.setGroupId(1L); request.setStudyId(1L); request.setMemberId(1L);
-        request.setDate(LocalDate.now()); request.setDays(1);
+        MultiValueMap<String, String> request = new LinkedMultiValueMap<>();
+        request.add("groupId", "1");
+        request.add("studyId", "1");
+        request.add("memberId", "1");
+        request.add("date", "2023-04-06");
+        request.add("days", "1");
+        request.add("page", "0");
+        request.add("size", "10");
 
         Member member = createMember("member", "member");
         Study study = createStudy("스터디");
@@ -95,9 +101,7 @@ class TicketControllerTest {
 
         //when
         ResultActions resultActions = mvc.perform(get("/api/v1/tickets")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(request)));
+                .params(request));
 
         //then
         resultActions.andExpect(status().isOk())
@@ -105,18 +109,18 @@ class TicketControllerTest {
                 .andDo(document("tickets-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("groupId").type(NUMBER).description("그룹 엔티티 아이디").optional(),
-                                fieldWithPath("studyId").type(NUMBER).description("스터디 엔티티 아이디").optional(),
-                                fieldWithPath("memberId").type(NUMBER).description("회원 엔티티 아이디").optional(),
-                                fieldWithPath("date").type(STRING)
+                        requestParameters(
+                                parameterWithName("groupId").description("그룹 엔티티 아이디").optional(),
+                                parameterWithName("studyId").description("스터디 엔티티 아이디").optional(),
+                                parameterWithName("memberId").description("회원 엔티티 아이디").optional(),
+                                parameterWithName("date")
                                         .attributes(getDateFormat()).attributes(getDefaultValue("오늘")).description("검색 시작 일자"),
-                                fieldWithPath("days").type(NUMBER)
+                                parameterWithName("days")
                                         .attributes(getDefaultValue("1")).description("검색 할 일수"),
-                                fieldWithPath("page").type(NUMBER)
+                                parameterWithName("page")
                                         .attributes(getDefaultValue("0")).description("페이지 번호"),
-                                fieldWithPath("size").type(NUMBER).
-                                        attributes(getDefaultValue("30")).description("페이지 사이즈")
+                                parameterWithName("size")
+                                        .attributes(getDefaultValue("30")).description("페이지 사이즈")
                         ),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),

--- a/src/test/java/seong/onlinestudy/controller/TicketMessageControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketMessageControllerTest.java
@@ -103,7 +103,7 @@ class TicketMessageControllerTest {
         em.clear();
 
         CustomStompFrameHandler<TicketDto> handler = new CustomStompFrameHandler<>(TicketDto.class);
-        this.stompSession.subscribe("/sub/group/" + group.getId(), handler);
+        this.stompSession.subscribe("/sub/groups/" + group.getId(), handler);
 
         //when
         Ticket findTicket = ticketRepository.findById(ticket.getId()).get();


### PR DESCRIPTION
## 개요
API 요청 URL 변경 및 문서 수정

## 작업 내용
단일 리소스를 대상으로 하는 API 요청 URL을 수정했습니다.
예) /member/{id} -> /members/{id}
기존 단수 명사를 사용하던 것에서 컬렉션 형식을 사용하도록 일괄 수정했습니다.
이에 맞추어 API 문서를 수정했습니다.
추가로 get 요청시 requestFields로 문서화 되던 것을 requestParameters로 일괄 수정했습니다.