### PR TITLE
ticketRecordService 리팩토링

### DIFF
--- a/src/main/java/seong/onlinestudy/controller/TicketRecordController.java
+++ b/src/main/java/seong/onlinestudy/controller/TicketRecordController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 import seong.onlinestudy.controller.response.Result;
 import seong.onlinestudy.dto.StudyRecordDto;
+import seong.onlinestudy.exception.InvalidSessionException;
+import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.request.record.RecordsGetRequest;
 import seong.onlinestudy.service.TicketRecordService;
 
@@ -25,8 +27,19 @@ public class TicketRecordController {
 
     @GetMapping("/records")
     public Result<List<StudyRecordDto>> getRecords(@Valid RecordsGetRequest request,
-                                                   @SessionAttribute(value = LOGIN_MEMBER, required = false) Long loginMemberId) {
-        List<StudyRecordDto> records = ticketRecordService.getRecords(request, loginMemberId);
+                                                   @SessionAttribute(value = LOGIN_MEMBER, required = false) Long memberId) {
+        //요청 조건 중 memberId가 있을 경우 로그인한 회원의 id 와 비교
+        if(request.getMemberId() != null) {
+            if(memberId == null) {
+                throw new InvalidSessionException("세션이 유효하지 않습니다.");
+            }
+
+            if(!memberId.equals(request.getMemberId())) {
+                throw new PermissionControlException("권한이 없습니다.");
+            }
+        }
+
+        List<StudyRecordDto> records = ticketRecordService.getRecords(request);
 
         return new Result<>("200", records);
     }

--- a/src/main/java/seong/onlinestudy/dto/RecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/RecordDto.java
@@ -25,13 +25,21 @@ public class RecordDto {
     @JsonIgnore
     private Set<Member> memberCounter = new HashSet<>();
 
-    public void compareStartAndEndTime(Ticket ticket) {
-        if(startTime.isAfter(ticket.getStartTime())) {
-            startTime = ticket.getStartTime();
+    public void changeFirstStartTimeAndLastEndTime(Ticket ticket) {
+        if(isFirstInput()) {
+            setStartAndEndTime(ticket);
+        } else {
+            if (startTime.isAfter(ticket.getStartTime())) {
+                startTime = ticket.getStartTime();
+            }
+            if (ticket.isExpired() && endTime.isBefore(ticket.getTicketRecord().getExpiredTime())) {
+                endTime = ticket.getTicketRecord().getExpiredTime();
+            }
         }
-        if(ticket.isExpired() && endTime.isBefore(ticket.getTicketRecord().getExpiredTime())) {
-            endTime = ticket.getTicketRecord().getExpiredTime();
-        }
+    }
+
+    private boolean isFirstInput() {
+        return startTime == null && endTime == null;
     }
 
     public void setStartAndEndTime(Ticket ticket) {
@@ -66,6 +74,7 @@ public class RecordDto {
         RecordDto recordDto = new RecordDto();
         recordDto.date = date;
         recordDto.memberCount = 0;
+        recordDto.studyTime = 0;
         return recordDto;
     }
 

--- a/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
+++ b/src/main/java/seong/onlinestudy/dto/StudyRecordDto.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import seong.onlinestudy.domain.Member;
 import seong.onlinestudy.domain.Study;
+import seong.onlinestudy.request.record.RecordsGetRequest;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.time.LocalDate;
+import java.util.*;
 
 @Data
 public class StudyRecordDto {
@@ -21,6 +20,33 @@ public class StudyRecordDto {
 
     @JsonIgnore
     Set<Member> members = new HashSet<>();
+
+    /**
+     *
+     * @param study 지정할 study
+     * @param recordsGroupByDate 날짜별로 필터링된 recordDto 목록
+     * @param request 시작 날짜와 일수를 가져오기 위한 request 객체
+     * @return 시작 날짜부터 정해진 일수까지의 recordDto 를 가진 studyRecordDto를 반환
+     */
+    public static StudyRecordDto from(Study study,
+                                      Map<LocalDate, RecordDto> recordsGroupByDate,
+                                      RecordsGetRequest request) {
+        StudyRecordDto studyRecordDto = new StudyRecordDto();
+
+        studyRecordDto.studyId = study.getId();
+        studyRecordDto.studyName = study.getName();
+        studyRecordDto.memberCount = 0;
+
+        LocalDate startDate = request.getStartDate();
+        LocalDate endDate = startDate.plusDays(request.getDays());
+        for(LocalDate date = request.getStartDate(); date.isBefore(endDate); date=date.plusDays(1)) {
+            RecordDto recordDto = recordsGroupByDate.get(date);
+            studyRecordDto.addRecord(recordDto);
+        }
+        studyRecordDto.updateMemberCount();
+
+        return studyRecordDto;
+    }
 
     /**
      * members 필드의 사이즈를 memberCount 필드에 지정한다.
@@ -38,16 +64,5 @@ public class StudyRecordDto {
 
         records.add(recordDto);
         members.addAll(recordDto.getMemberCounter());
-    }
-
-    public static StudyRecordDto from(Study study) {
-        StudyRecordDto studyRecordDto = new StudyRecordDto();
-        if(study != null) {
-            studyRecordDto.studyId = study.getId();
-            studyRecordDto.studyName = study.getName();
-            studyRecordDto.memberCount = 0;
-        }
-
-        return studyRecordDto;
     }
 }

--- a/src/main/java/seong/onlinestudy/service/TicketRecordService.java
+++ b/src/main/java/seong/onlinestudy/service/TicketRecordService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import seong.onlinestudy.constant.TimeConst;
 import seong.onlinestudy.domain.StudyTicket;
 import seong.onlinestudy.dto.RecordDto;
-import seong.onlinestudy.exception.PermissionControlException;
 import seong.onlinestudy.request.record.RecordsGetRequest;
 import seong.onlinestudy.domain.Study;
 import seong.onlinestudy.domain.Ticket;
@@ -22,13 +21,8 @@ public class TicketRecordService {
 
     private final TicketRepository ticketRepository;
 
-    public List<StudyRecordDto> getRecords(RecordsGetRequest request, Long loginMemberId) {
-        if(loginMemberId != null) {
-            //요청 조건 중 memberId가 있을 경우 로그인한 회원의 id 와 비교
-            if (request.getMemberId() != null && !loginMemberId.equals(request.getMemberId())) {
-                throw new PermissionControlException("권한이 없습니다.");
-            }
-        }
+    public List<StudyRecordDto> getRecords(RecordsGetRequest request) {
+
         LocalDateTime startTime = request.getStartDate().atStartOfDay().plusHours(TimeConst.DAY_START);
         LocalDateTime endTime = startTime.plusDays(request.getDays());
 

--- a/src/test/java/seong/onlinestudy/MyUtils.java
+++ b/src/test/java/seong/onlinestudy/MyUtils.java
@@ -11,6 +11,7 @@ import seong.onlinestudy.request.member.MemberCreateRequest;
 import seong.onlinestudy.request.post.PostCreateRequest;
 import seong.onlinestudy.request.study.StudyCreateRequest;
 
+import java.time.LocalDate;
 import java.util.*;
 
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -215,6 +216,7 @@ public class MyUtils {
         }
     }
 
+
     public static List<Ticket> createStudyTickets(List<Member> members, List<Group> groups, List<Study> studies, boolean setId) {
         List<Ticket> tickets = new ArrayList<>();
 
@@ -258,32 +260,6 @@ public class MyUtils {
         }
         return tickets;
     }
-
-    public static List<Ticket> createStudyTickets(TicketStatus status, List<Member> members, List<Group> groups,
-                                                  List<Study> studies, boolean setId) {
-        List<Ticket> tickets = new ArrayList<>();
-        for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createStudyTicket(members.get(i), groups.get(i % groups.size()), studies.get(i % studies.size()));
-            tickets.add(ticket);
-            setField(ticket, "id", (long)i);
-        }
-        return tickets;
-    }
-
-    public static List<Ticket> createEndTickets(List<Member> members, List<Group> groups, List<Study> studies, long studyTime) {
-        List<Ticket> tickets = new ArrayList<>();
-        for(int i=0; i<members.size(); i++) {
-            Ticket ticket = createStudyTicket(members.get(i), groups.get(i % groups.size()), studies.get(i % studies.size()));
-            tickets.add(ticket);
-        }
-        for (Ticket ticket : tickets) {
-            setField(ticket, "expired", true);
-            setField(ticket.getTicketRecord(), "expiredTime", ticket.getStartTime().plusSeconds(studyTime));
-            setField(ticket.getTicketRecord(), "activeTime", studyTime);
-        }
-        return tickets;
-    }
-
 
     public static void expireTickets(List<Ticket> tickets) {
         for (Ticket ticket : tickets) {

--- a/src/test/java/seong/onlinestudy/api/TicketRecordApiTest.java
+++ b/src/test/java/seong/onlinestudy/api/TicketRecordApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import seong.onlinestudy.constant.SessionConst;
 import seong.onlinestudy.domain.*;
 import seong.onlinestudy.enumtype.GroupRole;
 import seong.onlinestudy.repository.GroupRepository;
@@ -130,7 +131,7 @@ public class TicketRecordApiTest {
 
         //when
         MockHttpSession session = new MockHttpSession();
-        session.setAttribute("LOGIN_MEMBER", members.get(0));
+        session.setAttribute(SessionConst.LOGIN_MEMBER, members.get(0).getId());
         ResultActions resultActions = mvc.perform(get("/api/v1/records")
                 .params(request)
                 .session(session));

--- a/src/test/java/seong/onlinestudy/controller/TicketRecordControllerTest.java
+++ b/src/test/java/seong/onlinestudy/controller/TicketRecordControllerTest.java
@@ -94,7 +94,7 @@ class TicketRecordControllerTest {
 
         StudyRecordDto studyRecord = createStudyRecordDto(record);
 
-        given(ticketRecordService.getRecords(any(), any())).willReturn(List.of(studyRecord));
+        given(ticketRecordService.getRecords(any())).willReturn(List.of(studyRecord));
 
         //when
         ResultActions resultActions = mvc.perform(get("/api/v1/records")

--- a/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
@@ -71,7 +71,7 @@ class TicketRecordServiceTest {
         RecordsGetRequest request = new RecordsGetRequest();
         request.setStartDate(LocalDate.now());
         request.setDays(1);
-        List<StudyRecordDto> studyRecords = ticketRecordService.getRecords(request, members.get(0).getId());
+        List<StudyRecordDto> studyRecords = ticketRecordService.getRecords(request);
 
         //then
         assertThat(studyRecords.size()).isEqualTo(studies.size());
@@ -110,7 +110,7 @@ class TicketRecordServiceTest {
         //when
         RecordsGetRequest request = new RecordsGetRequest();
         request.setStudyId(studies.get(0).getId());
-        List<StudyRecordDto> records = ticketRecordService.getRecords(request, members.get(0).getId());
+        List<StudyRecordDto> records = ticketRecordService.getRecords(request);
 
         //then
         assertThat(records).allSatisfy(studyRecordDto -> {
@@ -145,7 +145,7 @@ class TicketRecordServiceTest {
         //when
         RecordsGetRequest request = new RecordsGetRequest();
         request.setStudyId(groups.get(0).getId());
-        List<StudyRecordDto> records = ticketRecordService.getRecords(request, members.get(0).getId());
+        List<StudyRecordDto> records = ticketRecordService.getRecords(request);
 
         //then
         List<Long> testTargetStudyIds = tickets.stream()

--- a/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
@@ -88,6 +88,10 @@ class TicketRecordServiceTest {
 
         assertThat(studyRecordDtos).allSatisfy(studyRecordDto -> {
             RecordDto recordDto = studyRecordDto.getRecords().get(request.getDays()-1);
+
+            LocalDate recordDtoDate = recordDto.getDate();
+            assertThat(recordDtoDate).isEqualTo(request.getStartDate());
+
             if (studyRecordDto.getStudyName().equals(studyA.getName())) {
                 assertThat(recordDto.getStudyTime()).isEqualTo(ticketPublishCount.get(studyA) * members.size() * 3600);
 
@@ -149,9 +153,14 @@ class TicketRecordServiceTest {
 
         assertThat(studyRecordDtos).allSatisfy(studyRecordDto -> {
             assertThat(studyRecordDto.getMemberCount()).isEqualTo(members.size());
+            assertThat(studyRecordDto.getRecords().size()).isEqualTo(request.getDays());
 
             assertThat(studyRecordDto.getRecords()).allSatisfy(recordDto -> {
-                if(recordDto.getDate().equals(LocalDate.now())) {  //현재 테스트 데이터는 LocalDate.now()만 이용하였음
+                LocalDate recordDtoDate = recordDto.getDate();
+                assertThat(recordDtoDate).isAfterOrEqualTo(request.getStartDate());
+                assertThat(recordDtoDate).isBeforeOrEqualTo(request.getStartDate().plusDays(request.getDays()));
+
+                if(recordDto.getDate().equals(LocalDate.now())) {  //현재 테스트 데이터의 date 는 LocalDate.now()만 이용하였음
                     if (studyRecordDto.getStudyName().equals(studyA.getName())) {
                         assertThat(recordDto.getStudyTime())
                                 .isEqualTo(ticketPublishCount.get(studyA) * members.size() * 3600);

--- a/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
+++ b/src/test/java/seong/onlinestudy/service/TicketRecordServiceTest.java
@@ -1,22 +1,24 @@
 package seong.onlinestudy.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import seong.onlinestudy.domain.*;
+import seong.onlinestudy.dto.RecordDto;
 import seong.onlinestudy.dto.StudyRecordDto;
 import seong.onlinestudy.enumtype.GroupRole;
 import seong.onlinestudy.repository.TicketRepository;
 import seong.onlinestudy.request.record.RecordsGetRequest;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,129 +36,147 @@ class TicketRecordServiceTest {
     @Mock
     TicketRepository ticketRepository;
 
-    List<Member> members;
-    List<Group> groups;
-    List<Study> studies;
-
-    List<Ticket> tickets;
-    List<StudyTicket> studyTickets;
-
-    @BeforeEach
-    void init() {
-        members = createMembers(50, true);
-        groups = createGroups(members, 10, true);
-        studies = createStudies(10, true);
-
-        joinMembersToGroups(members, groups);
-
-        tickets = createStudyTickets(members, groups, studies, true);
-        studyTickets = tickets.stream().map(ticket -> (StudyTicket) ticket).collect(Collectors.toList());
-
-        for (StudyTicket studyTicket : studyTickets) {
-            if(studyTicket.isExpired()) {
-                setField(studyTicket.getTicketRecord(), "activeTime", 1000L);
-                setField(studyTicket.getTicketRecord(), "expiredTime", studyTicket.getStartTime().plusSeconds(1000));
-            }
+    @Test
+    public void getRecords_day1() {
+        //given
+        List<Member> members = createMembers(5);
+        Group group = createGroup("group", 30, members.get(0));
+        for(int i=1; i<members.size(); i++) {
+            group.addGroupMember(GroupMember.createGroupMember(members.get(i), GroupRole.USER));
         }
-    }
+        Study studyA = createStudy("studyA");
+        Study studyB = createStudy("studyB");
+        List<Study> studies = List.of(studyA, studyB);
 
-    @Test
-    @DisplayName("공부 기록 목록 조회_조건 없음")
-    @Disabled("로컬 빌드시 통과, 젠킨스 빌드시 통과하지 못함. 수정 필요")
-    void getRecords_조건없음() {
-        //given
-        given(ticketRepository.findStudyTickets((Long)isNull(), any(), any(), any(), any())).willReturn(studyTickets);
+        Map<Study, Long> ticketPublishCount = new HashMap<>();
+        ticketPublishCount.put(studyA, 3L);
+        ticketPublishCount.put(studyB, 2L);
 
-        //when
-        RecordsGetRequest request = new RecordsGetRequest();
-        request.setStartDate(LocalDate.now());
-        request.setDays(1);
-        List<StudyRecordDto> studyRecords = ticketRecordService.getRecords(request);
-
-        //then
-        assertThat(studyRecords.size()).isEqualTo(studies.size());
-        assertThat(studyRecords).allSatisfy(studyRecordDto -> {
-            long testStudyTime = getTargetStudyTime(studyTickets, studyRecordDto.getStudyId());
-
-            assertThat(studyRecordDto.getMemberCount()).isGreaterThan(0);
-            assertThat(studyRecordDto.getRecords()).allSatisfy(recordDto -> {
-                assertThat(recordDto.getStudyTime()).isEqualTo(testStudyTime);
-            });
-        });
-    }
-
-    private long getTargetStudyTime(List<StudyTicket> studyTickets, Long studyId) {
-        List<StudyTicket> targetTestStudyTickets = studyTickets.stream()
-                .filter(studyTicket -> studyTicket.getStudy().getId().equals(studyId))
-                .collect(Collectors.toList());
-
-        long testStudyTime = 0;
-        for (StudyTicket targetTestStudyTicket : targetTestStudyTickets) {
-            if(targetTestStudyTicket.isExpired()) {
-                testStudyTime += targetTestStudyTicket.getTicketRecord().getActiveTime();
-            }
-        }
-        return testStudyTime;
-    }
-
-    @Test
-    @DisplayName("공부 기록 목록 조회_스터디 조건")
-    void getRecords_스터디조건() {
-        //given
-
-        given(ticketRepository.findStudyTickets((Long) isNull(), any(), any(), any(), any()))
-                .willReturn(studyTickets);
-
-        //when
-        RecordsGetRequest request = new RecordsGetRequest();
-        request.setStudyId(studies.get(0).getId());
-        List<StudyRecordDto> records = ticketRecordService.getRecords(request);
-
-        //then
-        assertThat(records).allSatisfy(studyRecordDto -> {
-            assertThat(studyRecordDto.getStudyId()).isNotNull();
-            assertThat(studyRecordDto.getStudyName()).isNotNull();
-            assertThat(studyRecordDto.getMemberCount()).isGreaterThan(0);
-        });
-    }
-
-    @Test
-    @DisplayName("공부 기록 목록 조회_그룹 조건")
-    void getRecords_그룹조건() {
-        //given
-        List<Member> members = createMembers(50, true);
-        List<Group> groups = createGroups(members, 10, true);
-        List<Study> studies = createStudies(10, true);
         List<StudyTicket> tickets = new ArrayList<>();
+        for (Member member : members) {
+            LocalDateTime startTime = LocalDateTime.now().minusHours(5);
+            for(int i=0; i<ticketPublishCount.get(studyA); i++) {
+                StudyTicket studyTicket = createExpiredStudyTicket(member, group, studyA, startTime.plusHours(1), 1);
 
-        for(int i=groups.size(); i<members.size(); i++) {
-            GroupMember groupMember = GroupMember.createGroupMember(members.get(i), GroupRole.USER);
-        }
-        for(int i=0; i<50; i++) {
-            Ticket ticket = createStudyTicket(members.get(i),
-                    groups.get(i % groups.size()), studies.get(i % studies.size()));
-            setField(ticket, "id", (long) i);
-            tickets.add((StudyTicket) ticket);
+                tickets.add(studyTicket);
+            }
+
+            for(int i=0; i<ticketPublishCount.get(studyB); i++) {
+                StudyTicket studyTicket = createExpiredStudyTicket(member, group, studyB, startTime.plusHours(1), 1);
+
+                tickets.add(studyTicket);
+            }
         }
 
-        given(ticketRepository.findStudyTickets((Long)isNull(), any(), any(), any(), any()))
+        given(ticketRepository.findStudyTickets(any(), any(), any(), any(), any()))
                 .willReturn(tickets);
 
         //when
         RecordsGetRequest request = new RecordsGetRequest();
-        request.setStudyId(groups.get(0).getId());
-        List<StudyRecordDto> records = ticketRecordService.getRecords(request);
+        request.setDays(1);
+        request.setStartDate(LocalDate.now());
+
+        List<StudyRecordDto> studyRecordDtos = ticketRecordService.getRecords(request);
 
         //then
-        List<Long> testTargetStudyIds = tickets.stream()
-                .map(studyTicket -> studyTicket.getStudy().getId())
-                .distinct()
-                .collect(Collectors.toList());
+        assertThat(studyRecordDtos.size()).isEqualTo(2);
 
-        List<Long> findStudyIds = records.stream()
-                .map(StudyRecordDto::getStudyId)
+        List<String> studyNames = studyRecordDtos.stream()
+                .map(StudyRecordDto::getStudyName)
                 .collect(Collectors.toList());
+        assertThat(studyNames).containsExactlyInAnyOrderElementsOf(List.of(studyA.getName(), studyB.getName()));
 
-        assertThat(findStudyIds).containsAnyElementsOf(testTargetStudyIds);
+        assertThat(studyRecordDtos).allSatisfy(studyRecordDto -> {
+            RecordDto recordDto = studyRecordDto.getRecords().get(request.getDays()-1);
+            if (studyRecordDto.getStudyName().equals(studyA.getName())) {
+                assertThat(recordDto.getStudyTime()).isEqualTo(ticketPublishCount.get(studyA) * members.size() * 3600);
+
+            } else if (studyRecordDto.getStudyName().equals(studyB.getName())) {
+                assertThat(recordDto.getStudyTime()).isEqualTo(ticketPublishCount.get(studyB) * members.size() * 3600);
+            }
+        });
+    }
+
+    @Test
+    public void getRecords_day7() {
+        //given
+        List<Member> members = createMembers(5);
+        Group group = createGroup("group", 30, members.get(0));
+        for(int i=1; i<members.size(); i++) {
+            group.addGroupMember(GroupMember.createGroupMember(members.get(i), GroupRole.USER));
+        }
+        Study studyA = createStudy("studyA");
+        Study studyB = createStudy("studyB");
+        List<Study> studies = List.of(studyA, studyB);
+
+        Map<Study, Long> ticketPublishCount = new HashMap<>();
+        ticketPublishCount.put(studyA, 3L);
+        ticketPublishCount.put(studyB, 2L);
+
+        List<StudyTicket> tickets = new ArrayList<>();
+        for (Member member : members) {
+            LocalDateTime startTime = LocalDateTime.now().minusHours(5);
+            for(int i=0; i<ticketPublishCount.get(studyA); i++) {
+                StudyTicket studyTicket = createExpiredStudyTicket(member, group, studyA, startTime.plusHours(1), 1);
+
+                tickets.add(studyTicket);
+            }
+
+            for(int i=0; i<ticketPublishCount.get(studyB); i++) {
+                StudyTicket studyTicket = createExpiredStudyTicket(member, group, studyB, startTime.plusHours(1), 1);
+
+                tickets.add(studyTicket);
+            }
+        }
+
+        given(ticketRepository.findStudyTickets(any(), any(), any(), any(), any()))
+                .willReturn(tickets);
+
+        //when
+        RecordsGetRequest request = new RecordsGetRequest();
+        request.setDays(7);
+        request.setStartDate(LocalDate.now().minusDays(6));
+
+        List<StudyRecordDto> studyRecordDtos = ticketRecordService.getRecords(request);
+
+        //then
+        assertThat(studyRecordDtos.size()).isEqualTo(2);
+
+        List<String> studyNames = studyRecordDtos.stream()
+                .map(StudyRecordDto::getStudyName)
+                .collect(Collectors.toList());
+        assertThat(studyNames).containsExactlyInAnyOrderElementsOf(List.of(studyA.getName(), studyB.getName()));
+
+        assertThat(studyRecordDtos).allSatisfy(studyRecordDto -> {
+            assertThat(studyRecordDto.getMemberCount()).isEqualTo(members.size());
+
+            assertThat(studyRecordDto.getRecords()).allSatisfy(recordDto -> {
+                if(recordDto.getDate().equals(LocalDate.now())) {  //현재 테스트 데이터는 LocalDate.now()만 이용하였음
+                    if (studyRecordDto.getStudyName().equals(studyA.getName())) {
+                        assertThat(recordDto.getStudyTime())
+                                .isEqualTo(ticketPublishCount.get(studyA) * members.size() * 3600);
+
+                    } else if (studyRecordDto.getStudyName().equals(studyB.getName())) {
+                        assertThat(recordDto.getStudyTime())
+                                .isEqualTo(ticketPublishCount.get(studyB) * members.size() * 3600);
+                    }
+                } else {
+                    assertThat(recordDto.getStartTime()).isNull();
+                    assertThat(recordDto.getEndTime()).isNull();
+                    assertThat(recordDto.getStudyTime()).isEqualTo(0);
+                    assertThat(recordDto.getMemberCount()).isEqualTo(0);
+                }
+            });
+        });
+
+    }
+
+    private StudyTicket createExpiredStudyTicket(Member member, Group group, Study studyA, LocalDateTime startTime, int hour) {
+        StudyTicket studyTicket = (StudyTicket) StudyTicket.createStudyTicket(member, group, studyA);
+        studyTicket.expireAndCreateRecord();
+        ReflectionTestUtils.setField(studyTicket, "startTime", startTime);
+        ReflectionTestUtils.setField(studyTicket.getTicketRecord(), "expiredTime", startTime.plusHours(hour));
+        ReflectionTestUtils.setField(studyTicket.getTicketRecord(), "activeTime", hour*3600);
+        return studyTicket;
     }
 }


### PR DESCRIPTION
ticketRecordService에 대한 리팩토링을 수행하였습니다.

기존 service 단에서 이루어지던 권한 검증 로직을 controller 단으로 옮겼습니다.
기존 service 단에서 이루어지던 dto 입력값에 대한 검증 로직을 해당 dto 메서드 내부로 옮겼습니다.
기존의 단위테스트에서 결과값에 대한 검증이 제대로 이루어지지 않아 재작성하였습니다.